### PR TITLE
[2기-C 남득윤] JPA 게시판 미션 - 리뷰 반영 개선 #150

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### html documentation
+src/docs/html/**

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
@@ -55,6 +54,17 @@
             <groupId>io.spring.asciidoctor</groupId>
             <artifactId>spring-asciidoctor-extensions</artifactId>
             <version>0.1.1.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>5.3.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>5.3.20</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/docs/asciidoc/overview.adoc
+++ b/src/docs/asciidoc/overview.adoc
@@ -5,3 +5,33 @@
 [[overview-host]]
 
 깃헙 : https://github.com/ndy2/springboot-board-jpa
+
+사용자 API 및 인증 서비스는 미구현 상태입니다. +
+게시글 API 의 요청,응답시에 아래의 초기 데이터를 세팅한 예시입니다.
+
+[source,json]
+----
+User : {
+    "id": n,
+    "loginId" : "ndy",
+    "name" : "득윤",
+    "hobby" : "체스"
+}
+
+User "ndy" 의 Posts : [
+    {
+      "postId" : n,
+      "title" : "제목1",
+      "content" : "내용1",
+      "writer" : "득윤",
+      "writtenDateTime" : "yyyy-MM-dd-HH-mm-ss.zzz"
+    },
+    {
+      "postId" : n,
+      "title" : "제목2",
+      "content" : "내용2",
+      "writer" : "득윤",
+      "writtenDateTime" : "yyyy-MM-dd-HH-mm-ss.zzz"
+    }
+]
+----

--- a/src/main/java/com/study/board/controller/GeneralExceptionHandler.java
+++ b/src/main/java/com/study/board/controller/GeneralExceptionHandler.java
@@ -11,6 +11,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+import static com.study.board.controller.GeneralExceptionHandler.ApiError.newResponse;
+
+
 @Slf4j
 @RestControllerAdvice
 public class GeneralExceptionHandler {
@@ -37,18 +40,18 @@ public class GeneralExceptionHandler {
         return newResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    private ResponseEntity<ApiError> newResponse(Throwable throwable, HttpStatus status) {
-        return new ResponseEntity<>(new ApiError(throwable, status), status);
-    }
-
     @Getter
-    private static class ApiError {
+    static class ApiError {
         private final String message;
         private final HttpStatus status;
 
-        public ApiError(Throwable throwable, HttpStatus status) {
+        private ApiError(Throwable throwable, HttpStatus status) {
             this.message = throwable.getMessage();
             this.status = status;
+        }
+
+        static ResponseEntity<ApiError> newResponse(Throwable throwable, HttpStatus status) {
+            return new ResponseEntity<>(new ApiError(throwable, status), status);
         }
     }
 }

--- a/src/main/java/com/study/board/controller/PostRestController.java
+++ b/src/main/java/com/study/board/controller/PostRestController.java
@@ -21,7 +21,7 @@ public class PostRestController {
     private final PostService postService;
 
     @GetMapping
-    public List<PostResponse> findAll(@PageableDefault(size = 20, sort = "writtenDateTime",  direction = DESC) Pageable pageable) {
+    public List<PostResponse> findAll(@PageableDefault(size = 20, sort = "writtenDateTime", direction = DESC) Pageable pageable) {
         return postService.findAll(pageable).stream().map(PostResponse::convert).collect(Collectors.toList());
     }
 

--- a/src/main/java/com/study/board/controller/PostRestController.java
+++ b/src/main/java/com/study/board/controller/PostRestController.java
@@ -31,27 +31,27 @@ public class PostRestController {
     }
 
     /**
-     * 인증 필요 - http 인가 헤더에 사용자 이름을 포함하는 것으로 대체
+     * 인증 필요 - http 인가 헤더에 로그인 아이디를 포함하는 것으로 대체
      */
     @PostMapping
-    public PostResponse upload(@RequestHeader("Authorization") String username, @RequestBody PostRequest postRequest) {
+    public PostResponse upload(@RequestHeader("Authorization") String loginId, @RequestBody PostRequest postRequest) {
         return PostResponse.convert(postService.write(
                 postRequest.getTitle(),
                 postRequest.getContent(),
-                username
+                loginId
         ));
     }
 
     /**
-     * 인증 필요 - http 인가 헤더에 사용자 이름을 포함하는 것으로 대체
+     * 인증 필요 - http 인가 헤더에 로그인 아이디를 포함하는 것으로 대체
      */
     @PutMapping("/{postId}")
-    public PostResponse edit(@RequestHeader("Authorization") String username, @RequestBody PostRequest postRequest, @PathVariable Long postId) {
+    public PostResponse edit(@RequestHeader("Authorization") String loginId, @RequestBody PostRequest postRequest, @PathVariable Long postId) {
         return PostResponse.convert(postService.edit(
                 postId,
                 postRequest.getTitle(),
                 postRequest.getContent(),
-                username
+                loginId
         ));
     }
 }

--- a/src/main/java/com/study/board/domain/post/domain/Post.java
+++ b/src/main/java/com/study/board/domain/post/domain/Post.java
@@ -47,9 +47,10 @@ public class Post extends BaseIdEntity {
         this.writer = writer;
     }
 
-    public Post edit(String title, String content) {
+    public Post edit(String title, String content, Long editorId) {
         checkTitle(title);
         checkContent(content);
+        checkEditable(editorId);
 
         this.title = title;
         this.content = content;
@@ -70,7 +71,9 @@ public class Post extends BaseIdEntity {
         checkNotNull(writer, "writer - null 이 될 수 없음");
     }
 
-    public boolean isWrittenBy(User user) {
-        return writer.getId().equals(user.getId());
+    private void checkEditable(Long editorId) {
+        if (!writer.getId().equals(editorId)) {
+            throw new IllegalArgumentException();
+        }
     }
 }

--- a/src/main/java/com/study/board/domain/post/service/PostService.java
+++ b/src/main/java/com/study/board/domain/post/service/PostService.java
@@ -10,7 +10,7 @@ public interface PostService {
 
     Post findById(Long postId);
 
-    Post write(String title, String content, String writerName);
+    Post write(String title, String content, String writerLoginId);
 
-    Post edit(Long postId, String title, String content, String editorName);
+    Post edit(Long postId, String title, String content, String editorLoginId);
 }

--- a/src/main/java/com/study/board/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/study/board/domain/post/service/PostServiceImpl.java
@@ -32,16 +32,16 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public Post write(String title, String content, String writerName) {
-        User writer = findUserByName(writerName);
+    public Post write(String title, String content, String writerLoginId) {
+        User writer = findUserByLoginId(writerLoginId);
         Post post = new Post(title, content, writer);
 
         return postRepository.save(post);
     }
 
     @Override
-    public Post edit(Long postId, String title, String content, String editorName) {
-        User editor = findUserByName(editorName);
+    public Post edit(Long postId, String title, String content, String editorLoginId) {
+        User editor = findUserByLoginId(editorLoginId);
         Post post = findPostById(postId);
 
         checkEditable(post, editor);
@@ -49,8 +49,8 @@ public class PostServiceImpl implements PostService {
         return post.edit(title, content);
     }
 
-    private User findUserByName(String name) {
-        return userRepository.findByName(name).orElseThrow(IllegalArgumentException::new);
+    private User findUserByLoginId(String name) {
+        return userRepository.findByLoginId(name).orElseThrow(IllegalArgumentException::new);
     }
 
     private Post findPostById(Long postId) {

--- a/src/main/java/com/study/board/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/study/board/domain/post/service/PostServiceImpl.java
@@ -44,9 +44,7 @@ public class PostServiceImpl implements PostService {
         User editor = findUserByLoginId(editorLoginId);
         Post post = findPostById(postId);
 
-        checkEditable(post, editor);
-
-        return post.edit(title, content);
+        return post.edit(title, content, editor.getId());
     }
 
     private User findUserByLoginId(String name) {
@@ -57,9 +55,5 @@ public class PostServiceImpl implements PostService {
         return postRepository.findById(postId).orElseThrow(IllegalArgumentException::new);
     }
 
-    private void checkEditable(Post post, User editor) {
-        if (!post.isWrittenBy(editor)) {
-            throw new IllegalArgumentException();
-        }
-    }
+
 }

--- a/src/main/java/com/study/board/domain/user/domain/User.java
+++ b/src/main/java/com/study/board/domain/user/domain/User.java
@@ -16,20 +16,27 @@ import static org.springframework.util.StringUtils.hasText;
 @NoArgsConstructor(access = PROTECTED)
 public class User extends BaseIdEntity {
 
+    public static final int USER_LOGIN_ID_MAX_LENGTH = 50;
     public static final int USER_NAME_MAX_LENGTH = 50;
     public static final int USER_HOBBY_MAX_LENGTH = 50;
 
-    @Column(name = "name", length = 50, nullable = false, unique = true)
+    @Column(name = "loginId", length = 20, nullable = false, unique = true)
+    private String loginId;
+
+    @Column(name = "name", length = 50, nullable = false)
     private String name;
 
     @Column(name = "hobby", length = 50)
     private String hobby;
 
-    public User(String name, String hobby) {
+    public User(String loginId, String name, String hobby) {
+        checkArgument(hasText(loginId), "loginId - 글자를 가져야함");
+        checkArgument(loginId.length() <= USER_LOGIN_ID_MAX_LENGTH, "loginId 길이 - " + USER_LOGIN_ID_MAX_LENGTH + " 이하 여야함");
         checkArgument(hasText(name), "name - 글자를 가져야함");
         checkArgument(name.length() <= USER_NAME_MAX_LENGTH, "name 길이 - " + USER_NAME_MAX_LENGTH + " 이하 여야함");
         checkArgument(hobby == null || hobby.length() <= USER_HOBBY_MAX_LENGTH, "hobby 길이 - " + USER_HOBBY_MAX_LENGTH + " 이하 여야함");
 
+        this.loginId = loginId;
         this.name = name;
         this.hobby = hobby;
     }

--- a/src/main/java/com/study/board/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/study/board/domain/user/repository/UserRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByName(String username);
+    Optional<User> findByLoginId(String username);
 }

--- a/src/main/java/com/study/board/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/study/board/domain/user/repository/UserRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByLoginId(String username);
+    Optional<User> findByLoginId(String loginId);
 }

--- a/src/test/java/com/study/board/controller/post/PostRestControllerTest.java
+++ b/src/test/java/com/study/board/controller/post/PostRestControllerTest.java
@@ -90,7 +90,7 @@ class PostRestControllerTest extends RestDocsTestSupport {
     void 게시글_단건_조회() throws Exception {
         Long targetPostId = post1.getId();
 
-        mockMvc.perform(get("/posts/{postId}", targetPostId )
+        mockMvc.perform(get("/posts/{postId}", targetPostId)
                         .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpectAll(

--- a/src/test/java/com/study/board/controller/post/PostRestControllerTest.java
+++ b/src/test/java/com/study/board/controller/post/PostRestControllerTest.java
@@ -122,7 +122,7 @@ class PostRestControllerTest extends RestDocsTestSupport {
                 .put("content", "내용");
 
         mockMvc.perform(post("/posts")
-                        .header(AUTHORIZATION, "득윤")
+                        .header(AUTHORIZATION, "ndy")
                         .contentType(APPLICATION_JSON)
                         .content(createJson(postRequest)))
                 .andExpect(status().isOk())
@@ -135,7 +135,7 @@ class PostRestControllerTest extends RestDocsTestSupport {
                 ).andDo(
                         restDocs.document(
                                 requestHeaders(
-                                        headerWithName(AUTHORIZATION).description("인증 대체 - 사용자 이름을 포함해주세요")
+                                        headerWithName(AUTHORIZATION).description("인증 대체 - 로그인 아이디를 포함해주세요")
                                 ),
                                 requestFields(
                                         fieldWithPath("title").type(JsonFieldType.STRING).description("게시글 제목"),
@@ -159,7 +159,7 @@ class PostRestControllerTest extends RestDocsTestSupport {
                 .put("content", "수정 내용");
 
         mockMvc.perform(put("/posts/" + postId)
-                        .header(AUTHORIZATION, "득윤")
+                        .header(AUTHORIZATION, "ndy")
                         .contentType(APPLICATION_JSON)
                         .content(createJson(postRequest)))
                 .andExpect(status().isOk())
@@ -172,7 +172,7 @@ class PostRestControllerTest extends RestDocsTestSupport {
                 ).andDo(
                         restDocs.document(
                                 requestHeaders(
-                                        headerWithName(AUTHORIZATION).description("인증 대체 - 사용자 이름을 포함해주세요")
+                                        headerWithName(AUTHORIZATION).description("인증 대체 - 로그인 아이디를 포함해주세요")
                                 ),
                                 requestFields(
                                         fieldWithPath("title").type(JsonFieldType.STRING).description("게시글 수정 제목"),

--- a/src/test/java/com/study/board/domain/post/domain/PostTest.java
+++ b/src/test/java/com/study/board/domain/post/domain/PostTest.java
@@ -1,9 +1,12 @@
 package com.study.board.domain.post.domain;
 
+import com.study.board.domain.user.domain.User;
 import org.assertj.core.internal.bytebuddy.utility.RandomString;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static com.study.board.domain.post.domain.Post.POST_TITLE_MAX_LENGTH;
 import static com.study.board.fixture.Fixture.createPost;
@@ -13,12 +16,23 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 class PostTest {
 
+    User aUser;
+    Post aPost;
+
+    @BeforeEach
+    void setUp() {
+        aUser = createUser();
+        ReflectionTestUtils.setField(aUser, "id", 1L);
+
+        aPost = new Post("제목", "내용", aUser);
+    }
+
     @Test
     void 생성_성공() {
         String title = "제목";
         String content = "내용";
 
-        Post post = new Post(title, content, createUser());
+        Post post = new Post(title, content, aUser);
 
         assertThat(post.getTitle()).isEqualTo(title);
         assertThat(post.getContent()).isEqualTo(content);
@@ -28,7 +42,7 @@ class PostTest {
     @ParameterizedTest
     void 제목이_null_이거나_비어있으면_생성실패(String title) {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new Post(title, "내용", createUser()));
+                .isThrownBy(() -> new Post(title, "내용", aUser));
     }
 
     @Test
@@ -36,21 +50,21 @@ class PostTest {
         String title = RandomString.make(POST_TITLE_MAX_LENGTH + 1);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new Post(title, "내용", createUser()));
+                .isThrownBy(() -> new Post(title, "내용", aUser));
     }
 
     @NullAndEmptySource
     @ParameterizedTest
     void 내용이_null_이거나_비어있으면_생성실패(String content) {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new Post("제목", content, createUser()));
+                .isThrownBy(() -> new Post("제목", content, aUser));
     }
 
     @Test
     void 수정_성공() {
-        Post post = createPost();
+        Post post = aPost;
 
-        Post editedPost = post.edit("수정제목", "수정내용");
+        Post editedPost = post.edit("수정제목", "수정내용", 1L);
 
         assertThat(editedPost).isEqualTo(post);
         assertThat(post.getTitle()).isEqualTo("수정제목");
@@ -61,7 +75,7 @@ class PostTest {
     @ParameterizedTest
     void 제목이_null_이거나_비어있으면_수정실패(String title) {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> createPost().edit(title, "수정내용"));
+                .isThrownBy(() -> aPost.edit(title, "수정내용", 1L));
     }
 
     @Test
@@ -69,13 +83,21 @@ class PostTest {
         String title = RandomString.make(POST_TITLE_MAX_LENGTH + 1);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> createPost().edit(title, "수정내용"));
+                .isThrownBy(() -> aPost.edit(title, "수정내용", 1L));
     }
 
     @NullAndEmptySource
     @ParameterizedTest
     void 내용이_null_이거나_비어있으면_수정실패(String content) {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> createPost().edit("수정제목", content));
+                .isThrownBy(() -> aPost.edit("수정제목", content, 1L));
+    }
+
+    @Test
+    void 수정_하는_사용자의_아이디가_작성자의_아이디와_다르면_수정실패() {
+        Long illegalEditorId = 2L;
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> aPost.edit("수정제목", "수정내용", illegalEditorId));
     }
 }

--- a/src/test/java/com/study/board/domain/post/domain/PostTest.java
+++ b/src/test/java/com/study/board/domain/post/domain/PostTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static com.study.board.domain.post.domain.Post.POST_TITLE_MAX_LENGTH;
-import static com.study.board.fixture.Fixture.createPost;
 import static com.study.board.fixture.Fixture.createUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;

--- a/src/test/java/com/study/board/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/study/board/domain/post/service/PostServiceImplTest.java
@@ -73,7 +73,7 @@ class PostServiceImplTest {
 
     @Test
     void 게시글_작성_성공() {
-        Post writtenPost = postService.write("제목", "내용", "득윤");
+        Post writtenPost = postService.write("제목", "내용", "ndy");
 
         Post foundPost = postRepository.findById(writtenPost.getId()).get();
 
@@ -86,7 +86,7 @@ class PostServiceImplTest {
     void 게시글_수정_성공() {
         Long editPostId = writtenPost1.getId();
 
-        Post editedPost = postService.edit(editPostId, "수정제목", "수정내용", "득윤");
+        Post editedPost = postService.edit(editPostId, "수정제목", "수정내용", "ndy");
 
         assertThat(editedPost).isEqualTo(writtenPost1);
         assertThat(editedPost.getTitle()).isEqualTo("수정제목");
@@ -98,14 +98,14 @@ class PostServiceImplTest {
         Long illegalPostId = -1L;
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> postService.edit(illegalPostId, "수정제목", "수정내용", "득윤"));
+                .isThrownBy(() -> postService.edit(illegalPostId, "수정제목", "수정내용", "ndy"));
     }
 
     @Test
     void 남의_게시글_수정_실패() {
-        User anotherUser = userRepository.save(new User("다른 사용자", null));
+        userRepository.save(new User("another", "다른 사용자", null));
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> postService.edit(writtenPost1.getId(), "수정제목", "수정내용", "다른 사용자"));
+                .isThrownBy(() -> postService.edit(writtenPost1.getId(), "수정제목", "수정내용", "another"));
     }
 }

--- a/src/test/java/com/study/board/domain/user/domain/UserTest.java
+++ b/src/test/java/com/study/board/domain/user/domain/UserTest.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
-import static com.study.board.domain.user.domain.User.USER_HOBBY_MAX_LENGTH;
-import static com.study.board.domain.user.domain.User.USER_NAME_MAX_LENGTH;
+import static com.study.board.domain.user.domain.User.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -14,7 +13,7 @@ class UserTest {
 
     @Test
     void 생성_성공() {
-        User user = new User("득윤", "체스");
+        User user = new User("ndy", "득윤", "체스");
 
         assertThat(user.getId()).isNull();
         assertThat(user.getName()).isEqualTo("득윤");
@@ -23,9 +22,24 @@ class UserTest {
 
     @NullAndEmptySource
     @ParameterizedTest
+    void 로그인_아이디가_null_이거나_비어있으면_생성실패(String loginId) {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new User(loginId, "득윤", "체스"));
+    }
+
+    @Test
+    void 로그인_아이디가의_길이가_제한_보다_크면_생성실패() {
+        String loginId = RandomString.make(USER_LOGIN_ID_MAX_LENGTH + 1);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new User(loginId, "득윤", "체스"));
+    }
+
+    @NullAndEmptySource
+    @ParameterizedTest
     void 이름이_null_이거나_비어있으면_생성실패(String name) {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new User(name, "체스"));
+                .isThrownBy(() -> new User("ndy", name, "체스"));
     }
 
     @Test
@@ -33,7 +47,7 @@ class UserTest {
         String name = RandomString.make(USER_NAME_MAX_LENGTH + 1);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new User(name, "체스"));
+                .isThrownBy(() -> new User("ndy", name, "체스"));
     }
 
     @Test
@@ -41,6 +55,6 @@ class UserTest {
         String hobby = RandomString.make(USER_HOBBY_MAX_LENGTH + 1);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new User("득윤", hobby));
+                .isThrownBy(() -> new User("ndy", "득윤", hobby));
     }
 }

--- a/src/test/java/com/study/board/fixture/Fixture.java
+++ b/src/test/java/com/study/board/fixture/Fixture.java
@@ -6,7 +6,7 @@ import com.study.board.domain.user.domain.User;
 public class Fixture {
 
     public static User createUser() {
-        return new User("득윤", "체스");
+        return new User("ndy", "득윤", "체스");
     }
 
     public static Post createPost() {

--- a/src/test/java/com/study/board/fixture/Fixture.java
+++ b/src/test/java/com/study/board/fixture/Fixture.java
@@ -2,6 +2,7 @@ package com.study.board.fixture;
 
 import com.study.board.domain.post.domain.Post;
 import com.study.board.domain.user.domain.User;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class Fixture {
 

--- a/src/test/java/com/study/board/fixture/Fixture.java
+++ b/src/test/java/com/study/board/fixture/Fixture.java
@@ -2,7 +2,6 @@ package com.study.board.fixture;
 
 import com.study.board.domain.post.domain.Post;
 import com.study.board.domain.user.domain.User;
-import org.springframework.test.util.ReflectionTestUtils;
 
 public class Fixture {
 


### PR DESCRIPTION
## ✅ 피드백 반영사항  
-  예외 응답 생성 메서드 위치 이동
     - `GeneralExceptionHandler.newResponse` -> `GeneralExceptionHandler.ApiError.newResponse`
     
- 인증 대체 방식 변경
    -  : 이름 -> 로그인 아이디 (사용자 엔티티의 필드 추가)
    
- 수정시 아이디 비교 로직 위치 이동
    -  서비스 -> 도메인 (수정 메서드에서 직접 호출)
    - domain test 에서 id 값에 따라 테스트가 깨지는 문제로 인해 계속 서비스에 두었었는데 
      `ReflectionTestUtils` 라는것을 알게되어서 게시글의 검증시 사용자의 fixture의 id 값을 채우는 것에 
      활용하여 로직을 옮길 수 있었습니다.