### PR TITLE
[3기-C 김환] 앨런팀 게시판 추가 미션 제출합니다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.1'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/board/common/exception/UnAuthorizedException.java
+++ b/src/main/java/com/example/board/common/exception/UnAuthorizedException.java
@@ -1,0 +1,8 @@
+package com.example.board.common.exception;
+
+public class UnAuthorizedException extends RuntimeException {
+
+  public UnAuthorizedException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/example/board/common/util/AuthorityUtils.java
+++ b/src/main/java/com/example/board/common/util/AuthorityUtils.java
@@ -1,0 +1,21 @@
+package com.example.board.common.util;
+
+import com.example.board.common.exception.UnAuthorizedException;
+import java.util.Arrays;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.util.Assert;
+
+public class AuthorityUtils {
+
+  private AuthorityUtils(){}
+
+  public static Cookie getCookie(HttpServletRequest request, String cookieName){
+    Assert.notNull(cookieName, "parameter [cookieName] should not be null");
+    return Arrays.stream(request.getCookies())
+        .filter(cookie -> cookieName.equals(cookie.getName()))
+        .findAny()
+        .orElseThrow(
+            () -> new UnAuthorizedException(String.format("Cookie name %s not found", cookieName)));
+  }
+}

--- a/src/main/java/com/example/board/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/example/board/domain/member/dto/MemberRequest.java
@@ -1,5 +1,19 @@
 package com.example.board.domain.member.dto;
 
-public record MemberRequest(String name, int age, String hobby) {
+import com.example.board.domain.member.entity.Member;
 
+public class MemberRequest {
+
+  private MemberRequest(){}
+
+  public record Login(String email, String password) {
+
+  }
+
+  public record SignUp(String name, String email, String password, int age, String hobby) {
+
+    public Member toEntity() {
+      return new Member(name, email, password, age, hobby);
+    }
+  }
 }

--- a/src/main/java/com/example/board/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/example/board/domain/member/dto/MemberResponse.java
@@ -9,13 +9,15 @@ public class MemberResponse {
 
   private MemberResponse(){}
 
-  public record Detail(Long id, String name, int age, String hobby, List<PostResponse.Shortcut> posts,
-                              LocalDateTime createdAt, LocalDateTime updatedAt){
+  public record Detail(Long id, String name, String email, String password, int age, String hobby, List<PostResponse.Shortcut> posts,
+                       LocalDateTime createdAt, LocalDateTime updatedAt){
 
     public static Detail from(Member member) {
       return new Detail(
           member.getId(),
           member.getName(),
+          member.getEmail(),
+          member.getPassword(),
           member.getAge(),
           member.getHobby(),
           member.getPosts()

--- a/src/main/java/com/example/board/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/example/board/domain/member/dto/MemberResponse.java
@@ -12,8 +12,8 @@ public class MemberResponse {
   public record Detail(Long id, String name, String email, String password, int age, String hobby, List<PostResponse.Shortcut> posts,
                        LocalDateTime createdAt, LocalDateTime updatedAt){
 
-    public static Detail from(Member member) {
-      return new Detail(
+    public Detail(Member member) {
+      this(
           member.getId(),
           member.getName(),
           member.getEmail(),
@@ -22,21 +22,19 @@ public class MemberResponse {
           member.getHobby(),
           member.getPosts()
               .stream()
-              .map(PostResponse.Shortcut::from)
+              .map(PostResponse.Shortcut::new)
               .toList(),
           member.getCreatedAt(),
-          member.getUpdatedAt()
-      );
+          member.getUpdatedAt());
     }
   }
 
   public record OnlyAuthor(Long id, String name) {
 
-    public static OnlyAuthor from(Member member) {
-      return new OnlyAuthor(
+    public OnlyAuthor(Member member) {
+      this(
           member.getId(),
-          member.getName()
-      );
+          member.getName());
     }
   }
 }

--- a/src/main/java/com/example/board/domain/member/entity/Member.java
+++ b/src/main/java/com/example/board/domain/member/entity/Member.java
@@ -69,6 +69,12 @@ public class Member extends BaseTimeEntity {
     this.hobby = hobby;
   }
 
+  public void login(String loginPassword) {
+    if(password.equals(loginPassword)){
+      throw new IllegalArgumentException("login failed. wrong password");
+    }
+  }
+
   public void addPost(Post post){
     posts.add(post);
   }

--- a/src/main/java/com/example/board/domain/member/entity/Member.java
+++ b/src/main/java/com/example/board/domain/member/entity/Member.java
@@ -16,7 +16,7 @@ import javax.persistence.UniqueConstraint;
 
 @Entity
 @Table(uniqueConstraints = {
-    @UniqueConstraint(name = "NAME_UNIQUE", columnNames = {"name"})})
+    @UniqueConstraint(name = "EMAIL_UNIQUE", columnNames = {"email"})})
 public class Member extends BaseTimeEntity {
 
   @Id
@@ -26,6 +26,12 @@ public class Member extends BaseTimeEntity {
 
   @Column(name = "name")
   private String name;
+
+  @Column(name = "email")
+  private String email;
+
+  @Column(name = "password")
+  private String password;
 
   @Column(name = "age")
   private int age;
@@ -38,8 +44,10 @@ public class Member extends BaseTimeEntity {
 
   protected Member(){}
 
-  public Member(String name, int age, String hobby) {
+  public Member(String name, String email, String password, int age, String hobby) {
     this.name = name;
+    this.email = email;
+    this.password = password;
     this.age = age;
     this.hobby = hobby;
   }
@@ -56,6 +64,14 @@ public class Member extends BaseTimeEntity {
 
   public String getName(){
     return name;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getPassword() {
+    return password;
   }
 
   public int getAge(){

--- a/src/main/java/com/example/board/domain/member/entity/Member.java
+++ b/src/main/java/com/example/board/domain/member/entity/Member.java
@@ -52,6 +52,10 @@ public class Member extends BaseTimeEntity {
     this.hobby = hobby;
   }
 
+  public void addPost(Post post){
+    posts.add(post);
+  }
+
   public void update(String newName, int newAge, String newHobby){
     name = newName;
     age = newAge;
@@ -83,6 +87,6 @@ public class Member extends BaseTimeEntity {
   }
 
   public List<Post> getPosts(){
-    return posts;
+    return new ArrayList<>(posts);
   }
 }

--- a/src/main/java/com/example/board/domain/member/entity/Member.java
+++ b/src/main/java/com/example/board/domain/member/entity/Member.java
@@ -17,6 +17,7 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.Length;
 
 @Entity
@@ -35,7 +36,8 @@ public class Member extends BaseTimeEntity {
   private String name;
 
   @NotNull
-  @Email
+  @Email(regexp = "[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,3}",
+      flags = Pattern.Flag.CASE_INSENSITIVE)
   @Column(name = "email")
   private String email;
 

--- a/src/main/java/com/example/board/domain/member/entity/Member.java
+++ b/src/main/java/com/example/board/domain/member/entity/Member.java
@@ -13,6 +13,11 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
 
 @Entity
 @Table(uniqueConstraints = {
@@ -24,18 +29,27 @@ public class Member extends BaseTimeEntity {
   @Column(name = "member_id")
   private Long id;
 
+  @NotNull
+  @Length(min = 2, max = 10)
   @Column(name = "name")
   private String name;
 
+  @NotNull
+  @Email
   @Column(name = "email")
   private String email;
 
+  @NotNull
+  @Length(min = 6, max = 20)
   @Column(name = "password")
   private String password;
 
+  @Min(value = 6)
+  @Max(value = 140)
   @Column(name = "age")
   private int age;
 
+  @Length(max = 20)
   @Column(name = "hobby")
   private String hobby;
 

--- a/src/main/java/com/example/board/domain/member/entity/Member.java
+++ b/src/main/java/com/example/board/domain/member/entity/Member.java
@@ -46,6 +46,7 @@ public class Member extends BaseTimeEntity {
   @Column(name = "password")
   private String password;
 
+  @NotNull
   @Min(value = 6)
   @Max(value = 140)
   @Column(name = "age")

--- a/src/main/java/com/example/board/domain/member/entity/Member.java
+++ b/src/main/java/com/example/board/domain/member/entity/Member.java
@@ -70,7 +70,7 @@ public class Member extends BaseTimeEntity {
   }
 
   public void login(String loginPassword) {
-    if(password.equals(loginPassword)){
+    if(!password.equals(loginPassword)){
       throw new IllegalArgumentException("login failed. wrong password");
     }
   }

--- a/src/main/java/com/example/board/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/board/domain/member/repository/MemberRepository.java
@@ -1,8 +1,10 @@
 package com.example.board.domain.member.repository;
 
 import com.example.board.domain.member.entity.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+  Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/example/board/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/board/domain/member/service/MemberService.java
@@ -39,15 +39,13 @@ public class MemberService {
             () -> new UnAuthorizedException(
                 String.format("email %s not found", loginRequest.email())));
 
-    if(wrongPassword(loginRequest.password(), member.getPassword())){
+    try{
+      member.login(loginRequest.password());
+      return member.getId();
+
+    } catch(IllegalArgumentException e){
       throw new UnAuthorizedException(
           String.format("password doesn't match. request: %s, actual: %s", loginRequest.password(), member.getPassword()));
     }
-
-    return member.getId();
-  }
-
-  private boolean wrongPassword(String expected, String actual){
-    return !expected.equals(actual);
   }
 }

--- a/src/main/java/com/example/board/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/board/domain/member/service/MemberService.java
@@ -24,7 +24,7 @@ public class MemberService {
     Member member = memberRepository.findById(id)
         .orElseThrow(
             () -> new NotFoundException(String.format("member id %d doesn't exist", id)));
-    return MemberResponse.Detail.from(member);
+    return new MemberResponse.Detail(member);
   }
 
   public Long save(MemberRequest.SignUp signUpRequest) {

--- a/src/main/java/com/example/board/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/example/board/domain/post/dto/PostRequest.java
@@ -1,4 +1,11 @@
 package com.example.board.domain.post.dto;
 
+import com.example.board.domain.member.entity.Member;
+import com.example.board.domain.post.entity.Post;
+
 public record PostRequest(String title, String content, Long memberId) {
+
+  public Post toEntity(Member member){
+    return new Post(title(), content(), member);
+  }
 }

--- a/src/main/java/com/example/board/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/example/board/domain/post/dto/PostResponse.java
@@ -3,35 +3,34 @@ package com.example.board.domain.post.dto;
 import com.example.board.domain.member.dto.MemberResponse;
 import com.example.board.domain.post.entity.Post;
 import java.time.LocalDateTime;
+
 public class PostResponse {
 
   private PostResponse(){}
 
   public record Shortcut(Long id, String title){
 
-    public static Shortcut from(Post post) {
-      return new Shortcut(
+    public Shortcut(Post post) {
+      this(
           post.getId(),
-          post.getTitle()
-      );
+          post.getTitle());
     }
   }
 
   public record Detail(Long id, String title, String content, MemberResponse.OnlyAuthor author,
                              LocalDateTime createdAt, LocalDateTime updatedAt, String createdBy, String updatedBy){
 
-    public static Detail from(Post post) {
-      return new Detail(
+    public Detail(Post post){
+      this(
           post.getId(),
           post.getTitle(),
           post.getContent(),
-          MemberResponse.OnlyAuthor
-              .from(post.getMember()),
+          new MemberResponse.OnlyAuthor(
+              post.getMember()),
           post.getCreatedAt(),
           post.getUpdatedAt(),
           post.getCreatedBy(),
-          post.getUpdatedBy()
-      );
+          post.getUpdatedBy());
     }
   }
 }

--- a/src/main/java/com/example/board/domain/post/entity/Post.java
+++ b/src/main/java/com/example/board/domain/post/entity/Post.java
@@ -66,7 +66,7 @@ public class Post extends BaseTimeEntity {
     }
 
     this.member = member;
-    this.member.getPosts().add(this);
+    this.member.addPost(this);
   }
 
   @PrePersist

--- a/src/main/java/com/example/board/domain/post/entity/Post.java
+++ b/src/main/java/com/example/board/domain/post/entity/Post.java
@@ -57,7 +57,7 @@ public class Post extends BaseTimeEntity {
   public void update(String newTitle, String newContent, String memberName){
     this.title = newTitle;
     this.content = newContent;
-    preUpdate(memberName);
+    this.updatedBy = memberName;
   }
 
   public void registerMember(Member member) {
@@ -73,10 +73,6 @@ public class Post extends BaseTimeEntity {
   public void prePersist(){
     this.createdBy = this.getMember().getName();
     this.updatedBy = this.createdBy;
-  }
-
-  private void preUpdate(String memberName){
-    this.updatedBy = memberName;
   }
 
   public Long getId() {

--- a/src/main/java/com/example/board/domain/post/service/PostService.java
+++ b/src/main/java/com/example/board/domain/post/service/PostService.java
@@ -33,7 +33,7 @@ public class PostService {
             () -> new NotFoundException(
                 String.format("NotFoundException post id: %d", postId)));
 
-    return PostResponse.Detail.from(post);
+    return new PostResponse.Detail(post);
   }
 
   @Transactional(readOnly = true)
@@ -41,7 +41,7 @@ public class PostService {
     Page<Post> page = postRepository.findAll(pageable);
 
     return page.map(
-        PostResponse.Shortcut::from);
+        PostResponse.Shortcut::new);
   }
 
   public Long save(PostRequest postRequest) {

--- a/src/main/java/com/example/board/domain/post/service/PostService.java
+++ b/src/main/java/com/example/board/domain/post/service/PostService.java
@@ -45,10 +45,8 @@ public class PostService {
   }
 
   public Long save(PostRequest postRequest) {
-    Long memberId = postRequest.memberId();
-    Member member = findMemberById(memberId);
-
-    Post post = new Post(postRequest.title(), postRequest.content(), member);
+    Member member = findMemberById(postRequest.memberId());
+    Post post = postRequest.toEntity(member);
     postRepository.save(post);
 
     return post.getId();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,3 +23,6 @@ spring:
         query.in_clause_parameter_padding: true # 성능 최적화에 관한 속성
         hbm2ddl:
           auto: create-drop # ddl 생성 전략. hibernate에서 제공해주는 properties를 같이 사용 가능
+
+set-cookie:
+  max-age: 3600

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,5 +24,6 @@ spring:
         hbm2ddl:
           auto: create-drop # ddl 생성 전략. hibernate에서 제공해주는 properties를 같이 사용 가능
 
-set-cookie:
+cookie:
+  name: loginId
   max-age: 3600

--- a/src/test/java/com/example/board/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/board/domain/member/controller/MemberControllerTest.java
@@ -12,6 +12,7 @@ import com.example.board.domain.member.dto.MemberRequest;
 import com.example.board.domain.member.repository.MemberRepository;
 import com.example.board.domain.member.service.MemberService;
 import com.example.board.domain.post.dto.PostRequest;
+import com.example.board.domain.post.repository.PostRepository;
 import com.example.board.domain.post.service.PostService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.servlet.http.Cookie;
@@ -32,22 +33,26 @@ import org.springframework.test.web.servlet.MockMvc;
 class MemberControllerTest {
 
   @Autowired
-  private MockMvc mockMvc;
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private PostRepository postRepository;
 
   @Autowired
   private MemberService memberService;
 
   @Autowired
-  private MemberRepository memberRepository;
+  private PostService postService;
 
   @Autowired
-  private PostService postService;
+  private MockMvc mockMvc;
 
   @Autowired
   private ObjectMapper objectMapper;
 
   @BeforeEach
   void tearDown(){
+    postRepository.deleteAll();
     memberRepository.deleteAll();
   }
 

--- a/src/test/java/com/example/board/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/board/domain/member/controller/MemberControllerTest.java
@@ -54,12 +54,12 @@ class MemberControllerTest {
   @DisplayName("사용자를 등록할 수 있습니다")
   void newMember() throws Exception {
     //given
-    MemberRequest memberRequest = new MemberRequest("김환", 25, "게임");
+    MemberRequest.SignUp signUpRequest = new MemberRequest.SignUp("김환", "email123@naver.com", "password123!", 25, "게임");
 
     //when & then
     mockMvc.perform(post("/members")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(memberRequest)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(signUpRequest)))
         .andExpect(status().isCreated())
         .andDo(print())
         .andDo(document("member-save",
@@ -74,8 +74,8 @@ class MemberControllerTest {
   @DisplayName("사용자를 조회할 수 있습니다")
   void findMemberById() throws Exception {
     //given
-    MemberRequest memberRequest = new MemberRequest("김환", 25, "게임");
-    Long savedMemberId = memberService.save(memberRequest);
+    MemberRequest.SignUp signUpRequest = new MemberRequest.SignUp("김환", "email123@naver.com", "password123!", 25, "게임");
+    Long savedMemberId = memberService.save(signUpRequest);
     postService.save(new PostRequest("으앙", "응아아아아앙", savedMemberId));
 
     //when & then

--- a/src/test/java/com/example/board/domain/member/entity/MemberTest.java
+++ b/src/test/java/com/example/board/domain/member/entity/MemberTest.java
@@ -6,86 +6,74 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class MemberTest {
+  private static final String NAME = "김환";
+  private static final String EMAIL = "email123@naver.com";
+  private static final String PASSWORD = "password123!";
+  private static final int AGE = 25;
+  private static final String HOBBY = "게임";
 
   @Test
   @DisplayName("Member를 생성합니다")
-  public void createMember(){
-    //given
-    String name = "김환";
-    String email = "email123@naver.com";
-    String password = "password123!";
-    int age = 25;
-    String hobby = "게임";
-
-    // when
-    Member member = new Member(name, email, password, age, hobby);
+  void createMember(){
+    //given & when
+    Member member = new Member(NAME, EMAIL, PASSWORD, AGE, HOBBY);
 
     //then
-    assertThat(member.getAge())
-        .isEqualTo(age);
-    assertThat(member.getName())
-        .isEqualTo(name);
-    assertThat(member.getHobby())
-        .isEqualTo(hobby);
+    String actualName = member.getName();
+    String actualEmail = member.getEmail();
+    String actualPassword = member.getPassword();
+    int actualAge = member.getAge();
+    String actualHobby = member.getHobby();
+
+    assertThat(actualName).isEqualTo("김환");
+    assertThat(actualEmail).isEqualTo("email123@naver.com");
+    assertThat(actualPassword).isEqualTo("password123!");
+    assertThat(actualAge).isEqualTo(25);
+    assertThat(actualHobby).isEqualTo("게임");
   }
 
   @Test
   @DisplayName("Member의 나이를 변경합니다")
-  public void updateMemberAge(){
+  void updateMemberAge(){
     //given
-    String name = "김환";
-    String email = "email123@naver.com";
-    String password = "password123!";
-    int age = 25;
-    String hobby = "게임";
-    Member member = new Member(name, email, password, age, hobby);
+    Member member = new Member(NAME, EMAIL, PASSWORD, AGE, HOBBY);
 
-    // when
+    //when
     int newAge = 10;
-    member.update(name, newAge, hobby);
+    member.update(NAME, newAge, HOBBY);
 
     //then
-    assertThat(member.getAge())
-        .isEqualTo(newAge);
+    int actualAge = member.getAge();
+    assertThat(actualAge).isEqualTo(10);
   }
 
   @Test
   @DisplayName("Member의 이름을 변경합니다")
-  public void updateMemberName(){
+  void updateMemberName(){
     //given
-    String name = "김환";
-    String email = "email123@naver.com";
-    String password = "password123!";
-    int age = 25;
-    String hobby = "게임";
-    Member member = new Member(name, email, password, age, hobby);
+    Member member = new Member(NAME, EMAIL, PASSWORD, AGE, HOBBY);
 
     // when
-    String newName = "김환";
-    member.update(newName, age, hobby);
+    String newName = "홍길동";
+    member.update(newName, AGE, HOBBY);
 
     //then
-    assertThat(member.getName())
-        .isEqualTo(newName);
+    String actualName = member.getName();
+    assertThat(actualName).isEqualTo("홍길동");
   }
 
   @Test
   @DisplayName("Member의 취미를 변경합니다")
-  public void updateMemberHobby(){
+  void updateMemberHobby(){
     //given
-    String name = "김환";
-    String email = "email123@naver.com";
-    String password = "password123!";
-    int age = 25;
-    String hobby = "게임";
-    Member member = new Member(name, email, password, age, hobby);
+    Member member = new Member(NAME, EMAIL, PASSWORD, AGE, HOBBY);
 
     // when
     String newHobby= "코딩";
-    member.update(name, age, newHobby);
+    member.update(NAME, AGE, newHobby);
 
     //then
-    assertThat(member.getHobby())
-        .isEqualTo(newHobby);
+    String actualHobby = member.getHobby();
+    assertThat(actualHobby).isEqualTo("코딩");
   }
 }

--- a/src/test/java/com/example/board/domain/member/entity/MemberTest.java
+++ b/src/test/java/com/example/board/domain/member/entity/MemberTest.java
@@ -12,11 +12,13 @@ class MemberTest {
   public void createMember(){
     //given
     String name = "김환";
+    String email = "email123@naver.com";
+    String password = "password123!";
     int age = 25;
     String hobby = "게임";
 
     // when
-    Member member = new Member(name, age, hobby);
+    Member member = new Member(name, email, password, age, hobby);
 
     //then
     assertThat(member.getAge())
@@ -32,9 +34,11 @@ class MemberTest {
   public void updateMemberAge(){
     //given
     String name = "김환";
+    String email = "email123@naver.com";
+    String password = "password123!";
     int age = 25;
     String hobby = "게임";
-    Member member = new Member(name, age, hobby);
+    Member member = new Member(name, email, password, age, hobby);
 
     // when
     int newAge = 10;
@@ -50,9 +54,11 @@ class MemberTest {
   public void updateMemberName(){
     //given
     String name = "김환";
+    String email = "email123@naver.com";
+    String password = "password123!";
     int age = 25;
     String hobby = "게임";
-    Member member = new Member(name, age, hobby);
+    Member member = new Member(name, email, password, age, hobby);
 
     // when
     String newName = "김환";
@@ -68,9 +74,11 @@ class MemberTest {
   public void updateMemberHobby(){
     //given
     String name = "김환";
+    String email = "email123@naver.com";
+    String password = "password123!";
     int age = 25;
     String hobby = "게임";
-    Member member = new Member(name, age, hobby);
+    Member member = new Member(name, email, password, age, hobby);
 
     // when
     String newHobby= "코딩";

--- a/src/test/java/com/example/board/domain/member/entity/MemberValidationTest.java
+++ b/src/test/java/com/example/board/domain/member/entity/MemberValidationTest.java
@@ -1,0 +1,186 @@
+package com.example.board.domain.member.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@TestInstance(Lifecycle.PER_CLASS)
+class MemberValidationTest {
+  private static final String NAME = "김환";
+  private static final String EMAIL = "email123@naver.com";
+  private static final String PASSWORD = "password123!";
+  private static final int AGE = 25;
+  private static final String HOBBY = "게임";
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private Validator validator;
+
+  @BeforeAll
+  public void setUp() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @Test
+  @DisplayName("사용자의 이름은 null일 수 없습니다")
+  void nameNotNull(){
+    //given & when
+    Member member = new Member(null, EMAIL, PASSWORD, AGE, HOBBY);
+
+    //then
+    Set<ConstraintViolation<Member>> violations = validator.validate(member);
+    violations.forEach(violation -> log.info("{}", violation));
+
+    int actualViolationSize = violations.size();
+    assertThat(actualViolationSize).isEqualTo(1);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"한", "열한글자열한글자열한글"})
+  @DisplayName("사용자의 이름은 한글이름 2글자 이상 10글자 이하여야 합니다")
+  void nameOutOfBoundary(String wrongBoundaryName){
+    //given & when
+    Member member = new Member(wrongBoundaryName, EMAIL, PASSWORD, AGE, HOBBY);
+
+    //then
+    Set<ConstraintViolation<Member>> violations = validator.validate(member);
+    violations.forEach(violation -> log.info("{}", violation));
+
+    int actualViolationSize = violations.size();
+    assertThat(actualViolationSize).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("사용자의 email은 null일 수 없습니다")
+  void emailNotNull(){
+    //given & when
+    Member member = new Member(NAME, null, PASSWORD, AGE, HOBBY);
+
+    //then
+    Set<ConstraintViolation<Member>> violations = validator.validate(member);
+    violations.forEach(violation -> log.info("{}", violation));
+
+    int actualViolationSize = violations.size();
+    assertThat(actualViolationSize).isEqualTo(1);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"abc", "qwe@", "@naver.com", "qwe.@naver.com", "qwe@@naver.com",
+      "q@we@naver.com", "qwe@naver..com"})
+  @DisplayName("사용자의 email은 알맞은 email의 형식이어야 합니다.")
+  void emailPatternNotMatch(String wrongEmailPatternString){
+    //given & when
+    Member member = new Member(NAME, wrongEmailPatternString, PASSWORD, AGE, HOBBY);
+
+    //then
+    Set<ConstraintViolation<Member>> violations = validator.validate(member);
+    violations.forEach(violation -> log.info("{}", violation));
+
+    int actualViolationSize = violations.size();
+    assertThat(actualViolationSize).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("사용자의 password는 null일 수 없습니다")
+  void passwordNotNull(){
+    //given & when
+    Member member = new Member(NAME, EMAIL, null, AGE, HOBBY);
+
+    //then
+    Set<ConstraintViolation<Member>> violations = validator.validate(member);
+    violations.forEach(violation -> log.info("{}", violation));
+
+    int actualViolationSize = violations.size();
+    assertThat(actualViolationSize).isEqualTo(1);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"abcde", "aaaaaaaaaaaaaaaaaaaaa"})
+  @DisplayName("사용자의 비밀번호는 6글자 이상 20글자 이하여야 합니다.")
+  void passwordOutOfBoundary(String wrongBoundaryPassword){
+    //given & when
+    Member member = new Member(NAME, EMAIL, wrongBoundaryPassword, AGE, HOBBY);
+
+    //then
+    Set<ConstraintViolation<Member>> violations = validator.validate(member);
+    violations.forEach(violation -> log.info("{}", violation));
+
+    int actualViolationSize = violations.size();
+    assertThat(actualViolationSize).isEqualTo(1);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {5, 141})
+  @DisplayName("사용자의 나이는 6세 이상 140세 이하여야 합니다.")
+  void ageOutOfBoundary(int wrongBoundaryAge){
+    //given & when
+    Member member = new Member(NAME, EMAIL, PASSWORD, wrongBoundaryAge, HOBBY);
+
+    //then
+    Set<ConstraintViolation<Member>> violations = validator.validate(member);
+    violations.forEach(violation -> log.info("{}", violation));
+
+    int actualViolationSize = violations.size();
+    assertThat(actualViolationSize).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("사용자의 취미는 없을 수 있습니다")
+  void hobbyCanBeNull(){
+    //given & when
+    Member member = new Member(NAME, EMAIL, PASSWORD, AGE, null);
+
+    //then
+    Set<ConstraintViolation<Member>> violations = validator.validate(member);
+    violations.forEach(violation -> log.info("{}", violation));
+
+    int actualViolationSize = violations.size();
+    assertThat(actualViolationSize).isZero();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"스물한글자취미스물한글자취미스물한글자취미"})
+  @DisplayName("사용자의 취미는 20글자 이하여야 합니다")
+  void hobbyOutOfBoundary(String wrongBoundaryHobby){
+    //given & when
+    Member member = new Member(NAME, EMAIL, PASSWORD, AGE, wrongBoundaryHobby);
+
+    //then
+    Set<ConstraintViolation<Member>> violations = validator.validate(member);
+    violations.forEach(violation -> log.info("{}", violation));
+
+    int actualViolationSize = violations.size();
+    assertThat(actualViolationSize).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("사용자가 잘못된 데이터로 사용자정보를 업데이트할 수 없습니다")
+  void updateFailure(){
+    //given
+    Member member = new Member(NAME, EMAIL, PASSWORD, AGE, HOBBY);
+
+    //when
+    member.update(null, -1, "스물한글자취미스물한글자취미스물한글자취미");
+
+    //then
+    Set<ConstraintViolation<Member>> violations = validator.validate(member);
+    violations.forEach(violation -> log.info("{}", violation));
+
+    int actualViolationSize = violations.size();
+    assertThat(actualViolationSize).isEqualTo(3);
+  }
+}

--- a/src/test/java/com/example/board/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/example/board/domain/post/controller/PostControllerTest.java
@@ -59,8 +59,8 @@ class PostControllerTest {
   @DisplayName("게시글을 생성할 수 있습니다.")
   void newPost() throws Exception {
     //given
-    MemberRequest memberRequest = new MemberRequest("김환", 25, "게임");
-    Long savedMemberId = memberService.save(memberRequest);
+    MemberRequest.SignUp signUpRequest = new MemberRequest.SignUp("김환", "email123@naver.com", "password123!", 25, "게임");
+    Long savedMemberId = memberService.save(signUpRequest);
     PostRequest postRequest = new PostRequest("제목", "내용", savedMemberId);
 
     //when & then
@@ -81,8 +81,8 @@ class PostControllerTest {
   @DisplayName("post_id로 게시글을 찾을 수 있습니다")
   void findPostById() throws Exception {
     //given
-    MemberRequest memberRequest = new MemberRequest("김환", 25, "게임");
-    Long savedMemberId = memberService.save(memberRequest);
+    MemberRequest.SignUp signUpRequest = new MemberRequest.SignUp("김환", "email123@naver.com", "password123!", 25, "게임");
+    Long savedMemberId = memberService.save(signUpRequest);
     PostRequest postRequest = new PostRequest("제목", "내용", savedMemberId);
     Long savedPostId = postService.save(postRequest);
 
@@ -109,8 +109,8 @@ class PostControllerTest {
   @DisplayName("게시글을 수정할 수 있습니다")
   void updatePost() throws Exception {
     //given
-    MemberRequest memberRequest = new MemberRequest("김환", 25, "게임");
-    Long savedMemberId = memberService.save(memberRequest);
+    MemberRequest.SignUp signUpRequest = new MemberRequest.SignUp("김환", "email123@naver.com", "password123!", 25, "게임");
+    Long savedMemberId = memberService.save(signUpRequest);
     PostRequest postRequest = new PostRequest("제목", "내용", savedMemberId);
     Long savedPostId = postService.save(postRequest);
 
@@ -118,8 +118,8 @@ class PostControllerTest {
 
     //when & then
     mockMvc.perform(put(String.format("/posts/%d", savedPostId))
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(updatePostRequest)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(updatePostRequest)))
         .andExpect(status().isCreated())
         .andDo(print())
         .andDo(document("post-update",

--- a/src/test/java/com/example/board/domain/post/entity/PostTest.java
+++ b/src/test/java/com/example/board/domain/post/entity/PostTest.java
@@ -7,16 +7,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class PostTest {
-  private static final String NAME = "김환";
-  private static final String EMAIL = "email123@naver.com";
-  private static final String PASSWORD = "password123!";
-  private static final int AGE = 25;
-  private static final String HOBBY = "게임";
 
   private static final String TITLE = "RBF";
   private static final String CONTENT = "RBF를 작성합니다";
 
-  private final Member member = new Member(NAME, EMAIL, PASSWORD, AGE, HOBBY);
+  private final Member member = new Member("김환", "email123@naver.com", "password123!", 25, "게임");
 
   @Test
   @DisplayName("Post를 생성할 수 있습니다")

--- a/src/test/java/com/example/board/domain/post/entity/PostTest.java
+++ b/src/test/java/com/example/board/domain/post/entity/PostTest.java
@@ -1,65 +1,82 @@
 package com.example.board.domain.post.entity;
 
+import static org.assertj.core.api.Assertions.*;
+
 import com.example.board.domain.member.entity.Member;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class PostTest {
+  private static final String NAME = "김환";
+  private static final String EMAIL = "email123@naver.com";
+  private static final String PASSWORD = "password123!";
+  private static final int AGE = 25;
+  private static final String HOBBY = "게임";
+
+  private static final String TITLE = "RBF";
+  private static final String CONTENT = "RBF를 작성합니다";
+
+  private final Member member = new Member(NAME, EMAIL, PASSWORD, AGE, HOBBY);
 
   @Test
   @DisplayName("Post를 생성할 수 있습니다")
   void newPost(){
-    //given
-    Member member = new Member("김환", "email123@naver.com", "password123!", 25, "게임");
-
-    //when
-    Post post = new Post("RBF", "RBF를 작성합니다", member);
-    String title = post.getTitle();
-    String content = post.getContent();
+    //given & when
+    Post post = new Post(TITLE, CONTENT, member);
 
     //then
-    Assertions.assertThat(post.getTitle())
-        .isEqualTo(title);
-    Assertions.assertThat(post.getContent())
-        .isEqualTo(content);
+    String actualTitle = post.getTitle();
+    String actualContent = post.getContent();
+
+    assertThat(actualTitle)
+        .isEqualTo("RBF");
+    assertThat(actualContent)
+        .isEqualTo("RBF를 작성합니다");
+  }
+
+  @Test
+  @DisplayName("Post를 생성 시 Member와의 연관관계를 설정합니다")
+  void mappingPostAndMember(){
+    //given & when
+    Post post = new Post(TITLE, CONTENT, member);
+
+    //then
+    int actualPostSize = member.getPosts().size();
+    Member actualMember = post.getMember();
+
+    assertThat(actualPostSize).isEqualTo(1);
+    assertThat(actualMember).isEqualTo(member);
   }
 
   @Test
   @DisplayName("Post의 제목을 변경할 수 있습니다")
   void updateTitle(){
     //given
-    Member member = new Member("김환", "email123@naver.com", "password123!", 25, "게임");
-    String title = "RBF";
-    String content = "RBF를 작성합니다";
-
-    Post post = new Post(title, content, member);
+    Post post = new Post(TITLE, CONTENT, member);
 
     //when
     String newTitle = "회고록";
-    post.update(newTitle, content, member.getName());
+    post.update(newTitle, CONTENT, member.getName());
 
     //then
-    Assertions.assertThat(post.getTitle())
-        .isEqualTo(newTitle);
+    String actualTitle = post.getTitle();
+    assertThat(actualTitle)
+        .isEqualTo("회고록");
   }
 
   @Test
   @DisplayName("Post의 내용을 변경할 수 있습니다")
   void updateContent(){
     //given
-    Member member = new Member("김환", "email123@naver.com", "password123!", 25, "게임");
-    String title = "RBF";
-    String content = "RBF를 작성합니다";
-
-    Post post = new Post(title, content, member);
+    Post post = new Post(TITLE, CONTENT, member);
 
     //when
     String newContent = "RBF를 더 많이 작성합니다";
-    post.update(title, newContent, member.getName());
+    post.update(TITLE, newContent, member.getName());
 
     //then
-    Assertions.assertThat(post.getContent())
-        .isEqualTo(newContent);
+    String actualContent = post.getContent();
+    assertThat(actualContent)
+        .isEqualTo("RBF를 더 많이 작성합니다");
   }
 }

--- a/src/test/java/com/example/board/domain/post/entity/PostTest.java
+++ b/src/test/java/com/example/board/domain/post/entity/PostTest.java
@@ -11,7 +11,7 @@ class PostTest {
   @DisplayName("Post를 생성할 수 있습니다")
   void newPost(){
     //given
-    Member member = new Member("김환", 25, "게임");
+    Member member = new Member("김환", "email123@naver.com", "password123!", 25, "게임");
 
     //when
     Post post = new Post("RBF", "RBF를 작성합니다", member);
@@ -29,7 +29,7 @@ class PostTest {
   @DisplayName("Post의 제목을 변경할 수 있습니다")
   void updateTitle(){
     //given
-    Member member = new Member("김환", 25, "게임");
+    Member member = new Member("김환", "email123@naver.com", "password123!", 25, "게임");
     String title = "RBF";
     String content = "RBF를 작성합니다";
 
@@ -48,7 +48,7 @@ class PostTest {
   @DisplayName("Post의 내용을 변경할 수 있습니다")
   void updateContent(){
     //given
-    Member member = new Member("김환", 25, "게임");
+    Member member = new Member("김환", "email123@naver.com", "password123!", 25, "게임");
     String title = "RBF";
     String content = "RBF를 작성합니다";
 


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 게시판 과제에 회원기능을 추가하였습니다.
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 회원가입기능
    - 사용자에게 이메일과 패스워드를 입력받아, 회원가입을 할 수 있습니다.
- 로그인 기능
    - 가입한 정보로 로그인을 할 수 있습니다.
    - 쿠키에 회원 id를 전달합니다.
- 내 정보 조회기능
    - 가입한 사용자는 자신의 정보를 조회할 수 있습니다.
    - 이 경우 로그인이 되어있어야하고, 본인만 정보를 조회할 수 있어야 합니다.
    - 쿠키의 회원 id를 통해 권한을 확인합니다.
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
승훈님 추가 리뷰의 반영사항이 있습니다! 코멘트로 코드라인에 추가 설명 남기겠습니다!
- 연관관계 참조 객체를 반환하는 getter에 방어적 복사를 적용하였습니다.
- 불필요한 메서드를 없앴습니다.
- 테스트 코드의 코드 중복을 줄였습니다.
- Entity 수준에서 validation을 진행하였습니다. Bean Validation을 사용하였습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
회원 기능에 대한 response를 어떻게 내려주는 것이 좋을지 고민해봤는데, 가장 좋은 방법을 찾지 못하였습니다. 이 과정에서 겪은 고민들을 공유해드립니다!
- 로그인, 로그아웃 기능에 대한 적절한 status를 정하지 못하였습니다. 회원가입은 201로 하는 것이 적절하다는 결론을 내렸는데, 로그인과 로그아웃은 Post요청이긴 하나 리소스가 생성되지 않는 요청이기 때문에 고민이 생겼던 것 같습니다.
- 회원가입, 로그인, 로그아웃 응답 헤더에 location으로 url을 넘겨주는 것이 좋을까요? 아니면 location url을 넘겨주지 않고 프론트에게 응답 이후의 과정을 위임하는 것이 좋을까요?