### PR TITLE
[3기-C 김선호] 앨런팀 게시판 추가 미션(2) 제출합니다.

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -6,46 +6,90 @@
 
 = 게시판 API
 
+== 사용자 인증
+
+=== 로그인
+
+==== 성공 - v1
+
+operation::member-login-v1[snippets='http-request,request-fields,http-response']
+
+==== 성공 - v2
+
+operation::member-login-v2[snippets='http-request,request-fields,http-response']
+
+==== 실패 - 유효하지 않은 이메일 - v2
+
+operation::member-login-fail-invalid-email-v2[snippets='http-request,request-fields,http-response,response-fields']
+
+==== 실패 - 유효하지 않은 비밀번호 - v2
+
+operation::member-login-fail-invalid-password-v2[snippets='http-request,request-fields,http-response,response-fields']
+
+=== 로그아웃
+
+==== 성공 - v1
+
+operation::member-logout-v1[snippets='http-request,http-response']
+
+==== 성공 - v2
+
+operation::member-logout-v2[snippets='http-request,http-response']
+
 == 회원
 
 === 회원 생성
 
-operation::member-join[snippets='http-request,request-fields,http-response']
+==== 성공 - v1
 
-=== 회원 조회
+operation::member-join-v1[snippets='http-request,request-fields,http-response']
 
-==== 단건 조회
+==== 성공 - v2
 
-operation::member-get-one[snippets='http-request,http-response,response-fields']
+operation::member-join-v2[snippets='http-request,request-fields,http-response']
 
-== 사용자 인증
+=== 회원 마이페이지
 
-=== 로그인/로그아웃
+==== 실패 - v1
 
-==== 로그인
+operation::member-my-page-v1[snippets='http-request,http-response,response-fields']
 
-operation::authentication-login[snippets='http-request,request-fields,http-response']
+==== 실패 - v2
 
-==== 로그아웃
-
-operation::authentication-logout[snippets='http-request,http-response']
+operation::member-my-page-v2[snippets='http-request,http-response,response-fields']
 
 == 게시글
 
 === 게시글 생성
 
-operation::post-create[snippets='http-request,http-response,response-fields']
+==== 성공 - v1
+
+operation::post-create-v1[snippets='http-request,http-response,response-fields']
+
+==== 성공 - v2
+
+operation::post-create-v1[snippets='http-request,http-response,response-fields']
+
+==== 실패 - v2
+
+operation::post-create-fail-v2[snippets='http-request,request-fields,http-response,response-fields']
 
 === 게시글 조회
 
 ==== 단건 조회
 
-operation::post-get-one[snippets='http-request,path-parameters,http-response,response-fields']
+operation::post-get-one-v1[snippets='http-request,path-parameters,http-response,response-fields']
 
 ==== 페이징 조회
 
-operation::post-get-all[snippets='http-request,request-parameters,http-response,response-fields']
+operation::post-get-all-v1[snippets='http-request,request-parameters,http-response,response-fields']
 
 === 게시글 수정
 
-operation::post-update[snippets='http-request,request-fields,path-parameters,http-response,response-fields']
+==== 성공
+
+operation::post-update-v1[snippets='http-request,request-fields,path-parameters,http-response,response-fields']
+
+==== 실패
+
+operation::post-update-fail-v2[snippets='http-request,request-fields,path-parameters,http-response,response-fields']

--- a/src/main/java/devcourse/board/domain/post/PostService.java
+++ b/src/main/java/devcourse/board/domain/post/PostService.java
@@ -28,8 +28,8 @@ public class PostService {
     }
 
     @Transactional
-    public Long createPost(PostCreationRequest creationRequest) {
-        Member findMember = memberService.findById(creationRequest.memberId());
+    public Long createPost(Long memberId, PostCreationRequest creationRequest) {
+        Member findMember = memberService.findById(memberId);
         Post newPost = Post.create(findMember, creationRequest.title(), creationRequest.content());
         postRepository.save(newPost);
 

--- a/src/main/java/devcourse/board/domain/post/PostService.java
+++ b/src/main/java/devcourse/board/domain/post/PostService.java
@@ -3,6 +3,7 @@ package devcourse.board.domain.post;
 import devcourse.board.domain.member.MemberService;
 import devcourse.board.domain.member.model.Member;
 import devcourse.board.domain.post.model.*;
+import devcourse.board.global.errors.exception.ForbiddenException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -66,7 +67,7 @@ public class PostService {
                     loggedInMemberId,
                     postId
             );
-            throw new IllegalStateException(MessageFormat.format(
+            throw new ForbiddenException(MessageFormat.format(
                     "Member ''{0}'' has no authority to update post.", loggedInMemberId
             ));
         }

--- a/src/main/java/devcourse/board/domain/post/model/PostCreationRequest.java
+++ b/src/main/java/devcourse/board/domain/post/model/PostCreationRequest.java
@@ -1,7 +1,6 @@
 package devcourse.board.domain.post.model;
 
 public record PostCreationRequest(
-        Long memberId,
         String title,
         String content
 ) {

--- a/src/main/java/devcourse/board/global/errors/GlobalExceptionHandler.java
+++ b/src/main/java/devcourse/board/global/errors/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package devcourse.board.global.errors;
 
+import devcourse.board.global.errors.exception.ForbiddenException;
+import devcourse.board.global.errors.exception.NoLoginMemberException;
 import devcourse.board.global.errors.model.ErrorResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,5 +47,19 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.warn("handleIllegalStateException", e);
         return ResponseEntity.badRequest()
                 .body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    private ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
+        log.warn("handleForbiddenException", e);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new ErrorResponse("No login info exists. Please login first."));
+    }
+
+    @ExceptionHandler(NoLoginMemberException.class)
+    private ResponseEntity<ErrorResponse> handleNoLoginMemberException(NoLoginMemberException e) {
+        log.warn("handleNoLoginMemberException", e);
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse("No login info exists. Please login first."));
     }
 }

--- a/src/main/java/devcourse/board/global/errors/exception/NoLoginMemberException.java
+++ b/src/main/java/devcourse/board/global/errors/exception/NoLoginMemberException.java
@@ -1,0 +1,8 @@
+package devcourse.board.global.errors.exception;
+
+public class NoLoginMemberException extends IllegalStateException {
+
+    public NoLoginMemberException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/devcourse/board/web/api/v1/LoginApiV1.java
+++ b/src/main/java/devcourse/board/web/api/v1/LoginApiV1.java
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 import static devcourse.board.web.authentication.AuthenticationUtil.COOKIE_NAME;
+import static devcourse.board.web.authentication.AuthenticationUtil.newEmptyCookie;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -39,10 +40,7 @@ public class LoginApiV1 {
     public ResponseEntity<Void> logout(
             HttpServletResponse response
     ) {
-        Cookie cookie = new Cookie(COOKIE_NAME, null);
-        cookie.setMaxAge(0);
-        response.addCookie(cookie);
-
+        response.addCookie(newEmptyCookie(COOKIE_NAME));
         return ResponseEntity.ok()
                 .build();
     }

--- a/src/main/java/devcourse/board/web/api/v1/MemberApiV1.java
+++ b/src/main/java/devcourse/board/web/api/v1/MemberApiV1.java
@@ -3,49 +3,30 @@ package devcourse.board.web.api.v1;
 import devcourse.board.domain.member.MemberService;
 import devcourse.board.domain.member.model.MemberJoinRequest;
 import devcourse.board.domain.member.model.MemberResponse;
-import devcourse.board.global.errors.exception.ForbiddenException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-import java.text.MessageFormat;
 
 import static devcourse.board.web.authentication.AuthenticationUtil.getLoggedInMemberId;
 
 @RestController
 @RequestMapping("/api/v1/members")
 public class MemberApiV1 {
-
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
-
+    
     private final MemberService memberService;
 
     public MemberApiV1(MemberService memberService) {
         this.memberService = memberService;
     }
 
-    @GetMapping("/{memberId}")
+    @GetMapping("/my-page")
     public ResponseEntity<MemberResponse> getMember(
-            HttpServletRequest request,
-            @PathVariable Long memberId
+            HttpServletRequest request
     ) {
         Long loggedInMemberId = getLoggedInMemberId(request);
-
-        if (!loggedInMemberId.equals(memberId)) {
-            log.warn(
-                    "An unauthorized member '{}' attempted to access information of member '{}'.",
-                    loggedInMemberId,
-                    memberId
-            );
-            throw new ForbiddenException(MessageFormat.format(
-                    "Refused to access information of member ''{0}''.", memberId
-            ));
-        }
-
         return ResponseEntity.ok()
                 .body(memberService.getMember(loggedInMemberId));
     }

--- a/src/main/java/devcourse/board/web/api/v1/PostApiV1.java
+++ b/src/main/java/devcourse/board/web/api/v1/PostApiV1.java
@@ -43,9 +43,11 @@ public class PostApiV1 {
 
     @PostMapping
     public ResponseEntity<CreateDataResponse> createPost(
+            HttpServletRequest request,
             @RequestBody PostCreationRequest creationRequest
     ) {
-        Long postIdentifier = postService.createPost(creationRequest);
+        Long loggedInMemberId = getLoggedInMemberId(request);
+        Long postIdentifier = postService.createPost(loggedInMemberId, creationRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new CreateDataResponse(postIdentifier));
     }

--- a/src/main/java/devcourse/board/web/api/v2/LoginApiV2.java
+++ b/src/main/java/devcourse/board/web/api/v2/LoginApiV2.java
@@ -1,4 +1,48 @@
 package devcourse.board.web.api.v2;
 
+import devcourse.board.domain.login.LoginService;
+import devcourse.board.domain.login.model.LoginRequest;
+import devcourse.board.web.authentication.SessionManager;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v2")
 public class LoginApiV2 {
+
+    private final SessionManager sessionManager;
+
+    private final LoginService loginService;
+
+    public LoginApiV2(SessionManager sessionManager, LoginService loginService) {
+        this.sessionManager = sessionManager;
+        this.loginService = loginService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(
+            @Valid @RequestBody LoginRequest loginRequest,
+            HttpServletResponse response
+    ) {
+        Long memberId = loginService.login(loginRequest);
+        sessionManager.registerNewSession(response, memberId);
+        return ResponseEntity.ok()
+                .build();
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            HttpServletRequest request
+    ) {
+        sessionManager.expireSession(request);
+        return ResponseEntity.ok()
+                .build();
+    }
 }

--- a/src/main/java/devcourse/board/web/api/v2/MemberApiV2.java
+++ b/src/main/java/devcourse/board/web/api/v2/MemberApiV2.java
@@ -1,4 +1,49 @@
 package devcourse.board.web.api.v2;
 
+
+import devcourse.board.domain.member.MemberService;
+import devcourse.board.domain.member.model.MemberJoinRequest;
+import devcourse.board.domain.member.model.MemberResponse;
+import devcourse.board.web.authentication.SessionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v2/members")
 public class MemberApiV2 {
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    private final SessionManager sessionManager;
+
+    private final MemberService memberService;
+
+    public MemberApiV2(SessionManager sessionManager, MemberService memberService) {
+        this.sessionManager = sessionManager;
+        this.memberService = memberService;
+    }
+
+    @GetMapping("/my-page")
+    public ResponseEntity<MemberResponse> getMember(
+            HttpServletRequest request
+    ) {
+        Long loginMemberId = sessionManager.getLoginMemberIdentifier(request);
+        return ResponseEntity.ok()
+                .body(memberService.getMember(loginMemberId));
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> join(
+            @Valid @RequestBody MemberJoinRequest joinRequest
+    ) {
+        memberService.join(joinRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .build();
+    }
 }

--- a/src/main/java/devcourse/board/web/api/v2/PostApiV2.java
+++ b/src/main/java/devcourse/board/web/api/v2/PostApiV2.java
@@ -1,4 +1,67 @@
 package devcourse.board.web.api.v2;
 
+import devcourse.board.domain.post.PostService;
+import devcourse.board.domain.post.model.PostCreationRequest;
+import devcourse.board.domain.post.model.PostResponse;
+import devcourse.board.domain.post.model.PostUpdateRequest;
+import devcourse.board.domain.post.model.SimplePostResponses;
+import devcourse.board.web.authentication.SessionManager;
+import devcourse.board.web.model.CreateDataResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/api/v2/posts")
 public class PostApiV2 {
+
+    private final SessionManager sessionManager;
+
+    private final PostService postService;
+
+    public PostApiV2(SessionManager sessionManager, PostService postService) {
+        this.sessionManager = sessionManager;
+        this.postService = postService;
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostResponse> getPost(
+            @PathVariable Long postId
+    ) {
+        return ResponseEntity.ok()
+                .body(postService.getPost(postId));
+    }
+
+    @GetMapping
+    public ResponseEntity<SimplePostResponses> getPosts(
+            @RequestParam int page,
+            @RequestParam int size
+    ) {
+        return ResponseEntity.ok()
+                .body(postService.findWithPaging(page, size));
+    }
+
+    @PostMapping
+    public ResponseEntity<CreateDataResponse> createPost(
+            HttpServletRequest request,
+            @RequestBody PostCreationRequest creationDto
+    ) {
+        Long loginMemberId = sessionManager.getLoginMemberIdentifier(request);
+        Long postId = postService.createPost(loginMemberId, creationDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new CreateDataResponse(postId));
+    }
+
+    @PatchMapping("/{postId}")
+    public ResponseEntity<PostResponse> updatePost(
+            HttpServletRequest request,
+            @PathVariable Long postId,
+            @RequestBody PostUpdateRequest updateRequest
+    ) {
+        Long loginMemberIdentifier = sessionManager.getLoginMemberIdentifier(request);
+        return ResponseEntity.ok()
+                .body(postService.updatePost(loginMemberIdentifier, postId, updateRequest));
+    }
 }

--- a/src/main/java/devcourse/board/web/authentication/AuthenticationUtil.java
+++ b/src/main/java/devcourse/board/web/authentication/AuthenticationUtil.java
@@ -9,6 +9,7 @@ import javax.servlet.http.HttpServletRequest;
 public class AuthenticationUtil {
 
     public static final String COOKIE_NAME = "memberId";
+    public static final String SESSION_NAME = "sessionId";
 
     private AuthenticationUtil() {
     }

--- a/src/main/java/devcourse/board/web/authentication/AuthenticationUtil.java
+++ b/src/main/java/devcourse/board/web/authentication/AuthenticationUtil.java
@@ -22,4 +22,11 @@ public class AuthenticationUtil {
 
         return Long.valueOf(memberIdCookie.getValue());
     }
+
+    public static Cookie newEmptyCookie(String cookieName) {
+        Cookie emptyCookie = new Cookie(cookieName, null);
+        emptyCookie.setPath("/");
+        emptyCookie.setMaxAge(0);
+        return emptyCookie;
+    }
 }

--- a/src/main/java/devcourse/board/web/authentication/AuthenticationUtil.java
+++ b/src/main/java/devcourse/board/web/authentication/AuthenticationUtil.java
@@ -1,5 +1,6 @@
 package devcourse.board.web.authentication;
 
+import devcourse.board.global.errors.exception.NoLoginMemberException;
 import org.springframework.web.util.WebUtils;
 
 import javax.servlet.http.Cookie;
@@ -16,7 +17,7 @@ public class AuthenticationUtil {
         Cookie memberIdCookie = WebUtils.getCookie(request, COOKIE_NAME);
 
         if (memberIdCookie == null) {
-            throw new IllegalStateException("No member logged in.");
+            throw new NoLoginMemberException("No member logged in.");
         }
 
         return Long.valueOf(memberIdCookie.getValue());

--- a/src/main/java/devcourse/board/web/authentication/SessionManager.java
+++ b/src/main/java/devcourse/board/web/authentication/SessionManager.java
@@ -1,0 +1,61 @@
+package devcourse.board.web.authentication;
+
+import devcourse.board.global.errors.exception.NoLoginMemberException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.WebUtils;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static devcourse.board.web.authentication.AuthenticationUtil.SESSION_NAME;
+
+@Component
+public class SessionManager {
+
+    private final Map<String, Long> sessionStorage = new ConcurrentHashMap<>();
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    @Value("${cookie.max-age}")
+    private int maxSessionAge;
+
+    public void registerNewSession(HttpServletResponse response, Long memberIdentifier) {
+        String sessionId = UUID.randomUUID().toString();
+        sessionStorage.put(sessionId, memberIdentifier);
+        addSessionToResponse(response, sessionId);
+    }
+
+    public void expireSession(HttpServletRequest request) {
+        Cookie sessionCookie = WebUtils.getCookie(request, SESSION_NAME);
+        if (sessionCookie != null) {
+            sessionStorage.remove(sessionCookie.getValue());
+        }
+    }
+
+    public Long getLoginMemberIdentifier(HttpServletRequest request) {
+        Cookie sessionCookie = WebUtils.getCookie(request, SESSION_NAME);
+        if (sessionCookie == null) {
+            throw new NoLoginMemberException("No cookie exists for cookieName=" + SESSION_NAME);
+        }
+
+        Long loginMemberIdentifier = sessionStorage.get(sessionCookie.getValue());
+        if (loginMemberIdentifier == null) {
+            throw new NoLoginMemberException("No session exists for sessionId=" + sessionCookie.getValue());
+        }
+        return loginMemberIdentifier;
+    }
+
+    private void addSessionToResponse(HttpServletResponse response, String cookieValue) {
+        Cookie cookie = new Cookie(SESSION_NAME, cookieValue);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxSessionAge);
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,17 +4,18 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
-
   jpa:
     hibernate:
       ddl-auto: create
     properties:
       hibernate:
         format_sql: true
-
   output:
     ansi:
       enabled: always
+
+cookie:
+  max-age: 600
 
 server:
   servlet:

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -2145,15 +2145,16 @@
   <div class="toc2" id="toc">
     <div id="toctitle">Table of Contents</div>
     <ul class="sectlevel1">
+      <li><a href="#_사용자_인증">사용자 인증</a>
+        <ul class="sectlevel2">
+          <li><a href="#_로그인">로그인</a></li>
+          <li><a href="#_로그아웃">로그아웃</a></li>
+        </ul>
+      </li>
       <li><a href="#_회원">회원</a>
         <ul class="sectlevel2">
           <li><a href="#_회원_생성">회원 생성</a></li>
-          <li><a href="#_회원_조회">회원 조회</a></li>
-        </ul>
-      </li>
-      <li><a href="#_사용자_인증">사용자 인증</a>
-        <ul class="sectlevel2">
-          <li><a href="#_로그인로그아웃">로그인/로그아웃</a></li>
+          <li><a href="#_회원_마이페이지">회원 마이페이지</a></li>
         </ul>
       </li>
       <li><a href="#_게시글">게시글</a>
@@ -2168,157 +2169,17 @@
 </div>
 <div id="content">
   <div class="sect1">
-    <h2 id="_회원">회원</h2>
-    <div class="sectionbody">
-      <div class="sect2">
-        <h3 id="_회원_생성">회원 생성</h3>
-        <div class="sect3">
-          <h4 id="_회원_생성_http_request">HTTP request</h4>
-          <div class="listingblock">
-            <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /members HTTP/1.1
-Content-Type: application/json;charset=UTF-8
-Content-Length: 87
-Host: localhost:8080
-
-{"email":"example@gmail.com","password":"0000","name":"member","age":null,"hobby":null}</code></pre>
-            </div>
-          </div>
-        </div>
-        <div class="sect3">
-          <h4 id="_회원_생성_request_fields">Request fields</h4>
-          <table class="tableblock frame-all grid-all stretch">
-            <colgroup>
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3334%;">
-            </colgroup>
-            <thead>
-            <tr>
-              <th class="tableblock halign-left valign-top">Path</th>
-              <th class="tableblock halign-left valign-top">Type</th>
-              <th class="tableblock halign-left valign-top">Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>age</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">나이</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>hobby</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">취미</p></td>
-            </tr>
-            </tbody>
-          </table>
-        </div>
-        <div class="sect3">
-          <h4 id="_회원_생성_http_response">HTTP response</h4>
-          <div class="listingblock">
-            <div class="content">
-              <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created</code></pre>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="sect2">
-        <h3 id="_회원_조회">회원 조회</h3>
-        <div class="sect3">
-          <h4 id="_단건_조회">단건 조회</h4>
-          <div class="sect4">
-            <h5 id="_단건_조회_http_request">HTTP request</h5>
-            <div class="listingblock">
-              <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /members/3 HTTP/1.1
-Host: localhost:8080
-Cookie: memberId=3</code></pre>
-              </div>
-            </div>
-          </div>
-          <div class="sect4">
-            <h5 id="_단건_조회_http_response">HTTP response</h5>
-            <div class="listingblock">
-              <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json
-Content-Length: 69
-
-{"email":"example@email.com","name":"member","age":null,"hobby":null}</code></pre>
-              </div>
-            </div>
-          </div>
-          <div class="sect4">
-            <h5 id="_단건_조회_response_fields">Response fields</h5>
-            <table class="tableblock frame-all grid-all stretch">
-              <colgroup>
-                <col style="width: 33.3333%;">
-                <col style="width: 33.3333%;">
-                <col style="width: 33.3334%;">
-              </colgroup>
-              <thead>
-              <tr>
-                <th class="tableblock halign-left valign-top">Path</th>
-                <th class="tableblock halign-left valign-top">Type</th>
-                <th class="tableblock halign-left valign-top">Description</th>
-              </tr>
-              </thead>
-              <tbody>
-              <tr>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
-              </tr>
-              <tr>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
-              </tr>
-              <tr>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>age</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock">나이</p></td>
-              </tr>
-              <tr>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>hobby</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock">취미</p></td>
-              </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="sect1">
     <h2 id="_사용자_인증">사용자 인증</h2>
     <div class="sectionbody">
       <div class="sect2">
-        <h3 id="_로그인로그아웃">로그인/로그아웃</h3>
+        <h3 id="_로그인">로그인</h3>
         <div class="sect3">
-          <h4 id="_로그인">로그인</h4>
+          <h4 id="_성공_v1">성공 - v1</h4>
           <div class="sect4">
-            <h5 id="_로그인_http_request">HTTP request</h5>
+            <h5 id="_성공_v1_http_request">HTTP request</h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /login HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/login HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 47
 Host: localhost:8080
@@ -2328,7 +2189,7 @@ Host: localhost:8080
             </div>
           </div>
           <div class="sect4">
-            <h5 id="_로그인_request_fields">Request fields</h5>
+            <h5 id="_성공_v1_request_fields">Request fields</h5>
             <table class="tableblock frame-all grid-all stretch">
               <colgroup>
                 <col style="width: 33.3333%;">
@@ -2357,7 +2218,7 @@ Host: localhost:8080
             </table>
           </div>
           <div class="sect4">
-            <h5 id="_로그인_http_response">HTTP response</h5>
+            <h5 id="_성공_v1_http_response">HTTP response</h5>
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2367,24 +2228,506 @@ Set-Cookie: memberId=1</code></pre>
           </div>
         </div>
         <div class="sect3">
-          <h4 id="_로그아웃">로그아웃</h4>
+          <h4 id="_성공_v2">성공 - v2</h4>
           <div class="sect4">
-            <h5 id="_로그아웃_http_request">HTTP request</h5>
+            <h5 id="_성공_v2_http_request">HTTP request</h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /logout HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v2/login HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 49
+Host: localhost:8080
+
+{"email":"email@email.com","password":"password"}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Set-Cookie: sessionId=552d7b74-abfd-4e3b-b47a-8dfaaecce69d; Path=/; Max-Age=600; Expires=Wed, 04 Jan 2023 16:36:41 GMT</code></pre>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="sect3">
+          <h4 id="_실패_유효하지_않은_이메일_v2">실패 - 유효하지 않은 이메일 - v2</h4>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_이메일_v2_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v2/login HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 56
+Host: localhost:8080
+
+{"email":"invalidEmail@email.com","password":"password"}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_이메일_v2_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_이메일_v2_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 97
+
+{"errorMessage":"존재하지 않는 회원이거나 비밀번호가 일치하지 않습니다."}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_이메일_v2_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>errorMessage</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">로그인 실패 사유</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="sect3">
+          <h4 id="_실패_유효하지_않은_비밀번호_v2">실패 - 유효하지 않은 비밀번호 - v2</h4>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_비밀번호_v2_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v2/login HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 56
+Host: localhost:8080
+
+{"email":"email@email.com","password":"invalidPassword"}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_비밀번호_v2_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_비밀번호_v2_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 97
+
+{"errorMessage":"존재하지 않는 회원이거나 비밀번호가 일치하지 않습니다."}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_비밀번호_v2_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>errorMessage</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">로그인 실패 사유</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="sect2">
+        <h3 id="_로그아웃">로그아웃</h3>
+        <div class="sect3">
+          <h4 id="_성공_v1_2">성공 - v1</h4>
+          <div class="sect4">
+            <h5 id="_성공_v1_2_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/logout HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
           </div>
           <div class="sect4">
-            <h5 id="_로그아웃_http_response">HTTP response</h5>
+            <h5 id="_성공_v1_2_http_response">HTTP response</h5>
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: memberId=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT</code></pre>
+Set-Cookie: memberId=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT</code></pre>
               </div>
             </div>
+          </div>
+        </div>
+        <div class="sect3">
+          <h4 id="_성공_v2_2">성공 - v2</h4>
+          <div class="sect4">
+            <h5 id="_성공_v2_2_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v2/logout HTTP/1.1
+Host: localhost:8080</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_2_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+                <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK</code></pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="sect1">
+    <h2 id="_회원">회원</h2>
+    <div class="sectionbody">
+      <div class="sect2">
+        <h3 id="_회원_생성">회원 생성</h3>
+        <div class="sect3">
+          <h4 id="_성공_v1_3">성공 - v1</h4>
+          <div class="sect4">
+            <h5 id="_성공_v1_3_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 87
+Host: localhost:8080
+
+{"email":"example@gmail.com","password":"0000","name":"member","age":null,"hobby":null}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v1_3_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>age</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">나이</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>hobby</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">취미</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v1_3_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+                <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created</code></pre>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="sect3">
+          <h4 id="_성공_v2_3">성공 - v2</h4>
+          <div class="sect4">
+            <h5 id="_성공_v2_3_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v2/members HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 87
+Host: localhost:8080
+
+{"email":"email@email.com","password":"password","name":"name","age":null,"hobby":null}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_3_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>age</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">나이</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>hobby</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">취미</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_3_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+                <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created</code></pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="sect2">
+        <h3 id="_회원_마이페이지">회원 마이페이지</h3>
+        <div class="sect3">
+          <h4 id="_실패_v1">실패 - v1</h4>
+          <div class="sect4">
+            <h5 id="_실패_v1_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/members/my-page HTTP/1.1
+Host: localhost:8080</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v1_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+Content-Length: 60
+
+{"errorMessage":"No login info exists. Please login first."}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v1_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>errorMessage</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">회원 정보 조회 불가 사유</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="sect3">
+          <h4 id="_실패_v2">실패 - v2</h4>
+          <div class="sect4">
+            <h5 id="_실패_v2_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v2/members/my-page HTTP/1.1
+Host: localhost:8080</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v2_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+Content-Length: 60
+
+{"errorMessage":"No login info exists. Please login first."}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v2_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>errorMessage</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">회원 정보 조회 불가 사유</p></td>
+              </tr>
+              </tbody>
+            </table>
           </div>
         </div>
       </div>
@@ -2396,73 +2739,211 @@ Set-Cookie: memberId=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT</code></
       <div class="sect2">
         <h3 id="_게시글_생성">게시글 생성</h3>
         <div class="sect3">
-          <h4 id="_게시글_생성_http_request">HTTP request</h4>
-          <div class="listingblock">
-            <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /posts HTTP/1.1
+          <h4 id="_성공_v1_4">성공 - v1</h4>
+          <div class="sect4">
+            <h5 id="_성공_v1_4_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/posts HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 50
+Content-Length: 47
 Host: localhost:8080
+Cookie: memberId=6
 
-{"memberId":6,"title":"title","content":"content"}</code></pre>
+{"title":"post-title","content":"post-content"}</code></pre>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="sect3">
-          <h4 id="_게시글_생성_http_response">HTTP response</h4>
-          <div class="listingblock">
-            <div class="content">
+          <div class="sect4">
+            <h5 id="_성공_v1_4_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
 Content-Type: application/json
 Content-Length: 16
 
 {"identifier":3}</code></pre>
+              </div>
             </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v1_4_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>identifier</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
+              </tr>
+              </tbody>
+            </table>
           </div>
         </div>
         <div class="sect3">
-          <h4 id="_게시글_생성_response_fields">Response fields</h4>
-          <table class="tableblock frame-all grid-all stretch">
-            <colgroup>
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3334%;">
-            </colgroup>
-            <thead>
-            <tr>
-              <th class="tableblock halign-left valign-top">Path</th>
-              <th class="tableblock halign-left valign-top">Type</th>
-              <th class="tableblock halign-left valign-top">Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>identifier</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
-            </tr>
-            </tbody>
-          </table>
+          <h4 id="_성공_v2_4">성공 - v2</h4>
+          <div class="sect4">
+            <h5 id="_성공_v2_4_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/posts HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 47
+Host: localhost:8080
+Cookie: memberId=6
+
+{"title":"post-title","content":"post-content"}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_4_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json
+Content-Length: 16
+
+{"identifier":3}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_4_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>identifier</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="sect3">
+          <h4 id="_실패_v2_2">실패 - v2</h4>
+          <div class="sect4">
+            <h5 id="_실패_v2_2_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v2/posts HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 47
+Host: localhost:8080
+
+{"title":"post-title","content":"post-content"}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v2_2_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 내용</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v2_2_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+Content-Length: 60
+
+{"errorMessage":"No login info exists. Please login first."}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v2_2_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>errorMessage</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 생성 불가 사유</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
       <div class="sect2">
         <h3 id="_게시글_조회">게시글 조회</h3>
         <div class="sect3">
-          <h4 id="_단건_조회_2">단건 조회</h4>
+          <h4 id="_단건_조회">단건 조회</h4>
           <div class="sect4">
-            <h5 id="_단건_조회_2_http_request">HTTP request</h5>
+            <h5 id="_단건_조회_http_request">HTTP request</h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /posts/2 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/posts/2 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Host: localhost:8080</code></pre>
               </div>
             </div>
           </div>
           <div class="sect4">
-            <h5 id="_단건_조회_2_path_parameters">Path parameters</h5>
+            <h5 id="_단건_조회_path_parameters">Path parameters</h5>
             <table class="tableblock frame-all grid-all stretch">
-              <caption class="title">Table 1. /posts/{postId}</caption>
+              <caption class="title">Table 1. /api/v1/posts/{postId}</caption>
               <colgroup>
                 <col style="width: 50%;">
                 <col style="width: 50%;">
@@ -2482,19 +2963,19 @@ Host: localhost:8080</code></pre>
             </table>
           </div>
           <div class="sect4">
-            <h5 id="_단건_조회_2_http_response">HTTP response</h5>
+            <h5 id="_단건_조회_http_response">HTTP response</h5>
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
 Content-Length: 120
 
-{"postId":2,"title":"post-title","content":"post-content","createdAt":"2023-01-03T17:35:24.932315","createdBy":"member"}</code></pre>
+{"postId":2,"title":"post-title","content":"post-content","createdAt":"2023-01-05T01:26:40.841429","createdBy":"member"}</code></pre>
               </div>
             </div>
           </div>
           <div class="sect4">
-            <h5 id="_단건_조회_2_response_fields">Response fields</h5>
+            <h5 id="_단건_조회_response_fields">Response fields</h5>
             <table class="tableblock frame-all grid-all stretch">
               <colgroup>
                 <col style="width: 33.3333%;">
@@ -2544,7 +3025,7 @@ Content-Length: 120
             <h5 id="_페이징_조회_http_request">HTTP request</h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /posts?page=0&amp;size=10 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/posts?page=0&amp;size=10 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Host: localhost:8080</code></pre>
               </div>
@@ -2629,125 +3110,232 @@ Content-Length: 59
       <div class="sect2">
         <h3 id="_게시글_수정">게시글 수정</h3>
         <div class="sect3">
-          <h4 id="_게시글_수정_http_request">HTTP request</h4>
-          <div class="listingblock">
-            <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /posts/4 HTTP/1.1
+          <h4 id="_성공">성공</h4>
+          <div class="sect4">
+            <h5 id="_성공_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/posts/4 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 45
 Host: localhost:8080
 Cookie: memberId=7
 
 {"title":"new-title","content":"new-content"}</code></pre>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="sect3">
-          <h4 id="_게시글_수정_request_fields">Request fields</h4>
-          <table class="tableblock frame-all grid-all stretch">
-            <colgroup>
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3334%;">
-            </colgroup>
-            <thead>
-            <tr>
-              <th class="tableblock halign-left valign-top">Path</th>
-              <th class="tableblock halign-left valign-top">Type</th>
-              <th class="tableblock halign-left valign-top">Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 내용</p></td>
-            </tr>
-            </tbody>
-          </table>
-        </div>
-        <div class="sect3">
-          <h4 id="_게시글_수정_path_parameters">Path parameters</h4>
-          <table class="tableblock frame-all grid-all stretch">
-            <caption class="title">Table 1. /posts/{postId}</caption>
-            <colgroup>
-              <col style="width: 50%;">
-              <col style="width: 50%;">
-            </colgroup>
-            <thead>
-            <tr>
-              <th class="tableblock halign-left valign-top">Parameter</th>
-              <th class="tableblock halign-left valign-top">Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
-            </tr>
-            </tbody>
-          </table>
-        </div>
-        <div class="sect3">
-          <h4 id="_게시글_수정_http_response">HTTP response</h4>
-          <div class="listingblock">
-            <div class="content">
+          <div class="sect4">
+            <h5 id="_성공_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 내용</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_path_parameters">Path parameters</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <caption class="title">Table 1. /api/v1/posts/{postId}</caption>
+              <colgroup>
+                <col style="width: 50%;">
+                <col style="width: 50%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Parameter</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
 Content-Length: 118
 
-{"postId":4,"title":"new-title","content":"new-content","createdAt":"2023-01-03T17:35:25.011568","createdBy":"member"}</code></pre>
+{"postId":4,"title":"new-title","content":"new-content","createdAt":"2023-01-05T01:26:40.910983","createdBy":"member"}</code></pre>
+              </div>
             </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 내용</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdAt</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 아이디</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdBy</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 작성자 이름</p></td>
+              </tr>
+              </tbody>
+            </table>
           </div>
         </div>
         <div class="sect3">
-          <h4 id="_게시글_수정_response_fields">Response fields</h4>
-          <table class="tableblock frame-all grid-all stretch">
-            <colgroup>
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3334%;">
-            </colgroup>
-            <thead>
-            <tr>
-              <th class="tableblock halign-left valign-top">Path</th>
-              <th class="tableblock halign-left valign-top">Type</th>
-              <th class="tableblock halign-left valign-top">Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 내용</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdAt</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 아이디</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdBy</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 작성자 이름</p></td>
-            </tr>
-            </tbody>
-          </table>
+          <h4 id="_실패">실패</h4>
+          <div class="sect4">
+            <h5 id="_실패_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v2/posts/5 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 45
+Host: localhost:8080
+Cookie: sessionId=aaed7515-f4a4-4551-8fe9-bcf8bb357a65
+
+{"title":"new-title","content":"new-content"}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 내용</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_path_parameters">Path parameters</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <caption class="title">Table 1. /api/v2/posts/{postId}</caption>
+              <colgroup>
+                <col style="width: 50%;">
+                <col style="width: 50%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Parameter</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 403 Forbidden
+Content-Type: application/json
+Content-Length: 60
+
+{"errorMessage":"No login info exists. Please login first."}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>errorMessage</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 생성 불가 사유</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     </div>
@@ -2756,7 +3344,7 @@ Content-Length: 118
 <div id="footer">
   <div id="footer-text">
     Version 0.0.1-SNAPSHOT<br>
-    Last updated 2023-01-03 17:34:55 +0900
+    Last updated 2023-01-05 01:25:00 +0900
   </div>
 </div>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css" rel="stylesheet">

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -2145,15 +2145,16 @@
   <div class="toc2" id="toc">
     <div id="toctitle">Table of Contents</div>
     <ul class="sectlevel1">
+      <li><a href="#_사용자_인증">사용자 인증</a>
+        <ul class="sectlevel2">
+          <li><a href="#_로그인">로그인</a></li>
+          <li><a href="#_로그아웃">로그아웃</a></li>
+        </ul>
+      </li>
       <li><a href="#_회원">회원</a>
         <ul class="sectlevel2">
           <li><a href="#_회원_생성">회원 생성</a></li>
-          <li><a href="#_회원_조회">회원 조회</a></li>
-        </ul>
-      </li>
-      <li><a href="#_사용자_인증">사용자 인증</a>
-        <ul class="sectlevel2">
-          <li><a href="#_로그인로그아웃">로그인/로그아웃</a></li>
+          <li><a href="#_회원_마이페이지">회원 마이페이지</a></li>
         </ul>
       </li>
       <li><a href="#_게시글">게시글</a>
@@ -2168,157 +2169,17 @@
 </div>
 <div id="content">
   <div class="sect1">
-    <h2 id="_회원">회원</h2>
-    <div class="sectionbody">
-      <div class="sect2">
-        <h3 id="_회원_생성">회원 생성</h3>
-        <div class="sect3">
-          <h4 id="_회원_생성_http_request">HTTP request</h4>
-          <div class="listingblock">
-            <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /members HTTP/1.1
-Content-Type: application/json;charset=UTF-8
-Content-Length: 87
-Host: localhost:8080
-
-{"email":"example@gmail.com","password":"0000","name":"member","age":null,"hobby":null}</code></pre>
-            </div>
-          </div>
-        </div>
-        <div class="sect3">
-          <h4 id="_회원_생성_request_fields">Request fields</h4>
-          <table class="tableblock frame-all grid-all stretch">
-            <colgroup>
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3334%;">
-            </colgroup>
-            <thead>
-            <tr>
-              <th class="tableblock halign-left valign-top">Path</th>
-              <th class="tableblock halign-left valign-top">Type</th>
-              <th class="tableblock halign-left valign-top">Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>age</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">나이</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>hobby</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">취미</p></td>
-            </tr>
-            </tbody>
-          </table>
-        </div>
-        <div class="sect3">
-          <h4 id="_회원_생성_http_response">HTTP response</h4>
-          <div class="listingblock">
-            <div class="content">
-              <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created</code></pre>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="sect2">
-        <h3 id="_회원_조회">회원 조회</h3>
-        <div class="sect3">
-          <h4 id="_단건_조회">단건 조회</h4>
-          <div class="sect4">
-            <h5 id="_단건_조회_http_request">HTTP request</h5>
-            <div class="listingblock">
-              <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /members/3 HTTP/1.1
-Host: localhost:8080
-Cookie: memberId=3</code></pre>
-              </div>
-            </div>
-          </div>
-          <div class="sect4">
-            <h5 id="_단건_조회_http_response">HTTP response</h5>
-            <div class="listingblock">
-              <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json
-Content-Length: 69
-
-{"email":"example@email.com","name":"member","age":null,"hobby":null}</code></pre>
-              </div>
-            </div>
-          </div>
-          <div class="sect4">
-            <h5 id="_단건_조회_response_fields">Response fields</h5>
-            <table class="tableblock frame-all grid-all stretch">
-              <colgroup>
-                <col style="width: 33.3333%;">
-                <col style="width: 33.3333%;">
-                <col style="width: 33.3334%;">
-              </colgroup>
-              <thead>
-              <tr>
-                <th class="tableblock halign-left valign-top">Path</th>
-                <th class="tableblock halign-left valign-top">Type</th>
-                <th class="tableblock halign-left valign-top">Description</th>
-              </tr>
-              </thead>
-              <tbody>
-              <tr>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
-              </tr>
-              <tr>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
-              </tr>
-              <tr>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>age</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock">나이</p></td>
-              </tr>
-              <tr>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>hobby</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-                <td class="tableblock halign-left valign-top"><p class="tableblock">취미</p></td>
-              </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="sect1">
     <h2 id="_사용자_인증">사용자 인증</h2>
     <div class="sectionbody">
       <div class="sect2">
-        <h3 id="_로그인로그아웃">로그인/로그아웃</h3>
+        <h3 id="_로그인">로그인</h3>
         <div class="sect3">
-          <h4 id="_로그인">로그인</h4>
+          <h4 id="_성공_v1">성공 - v1</h4>
           <div class="sect4">
-            <h5 id="_로그인_http_request">HTTP request</h5>
+            <h5 id="_성공_v1_http_request">HTTP request</h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /login HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/login HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 47
 Host: localhost:8080
@@ -2328,7 +2189,7 @@ Host: localhost:8080
             </div>
           </div>
           <div class="sect4">
-            <h5 id="_로그인_request_fields">Request fields</h5>
+            <h5 id="_성공_v1_request_fields">Request fields</h5>
             <table class="tableblock frame-all grid-all stretch">
               <colgroup>
                 <col style="width: 33.3333%;">
@@ -2357,7 +2218,7 @@ Host: localhost:8080
             </table>
           </div>
           <div class="sect4">
-            <h5 id="_로그인_http_response">HTTP response</h5>
+            <h5 id="_성공_v1_http_response">HTTP response</h5>
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2367,24 +2228,506 @@ Set-Cookie: memberId=1</code></pre>
           </div>
         </div>
         <div class="sect3">
-          <h4 id="_로그아웃">로그아웃</h4>
+          <h4 id="_성공_v2">성공 - v2</h4>
           <div class="sect4">
-            <h5 id="_로그아웃_http_request">HTTP request</h5>
+            <h5 id="_성공_v2_http_request">HTTP request</h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /logout HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v2/login HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 49
+Host: localhost:8080
+
+{"email":"email@email.com","password":"password"}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Set-Cookie: sessionId=552d7b74-abfd-4e3b-b47a-8dfaaecce69d; Path=/; Max-Age=600; Expires=Wed, 04 Jan 2023 16:36:41 GMT</code></pre>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="sect3">
+          <h4 id="_실패_유효하지_않은_이메일_v2">실패 - 유효하지 않은 이메일 - v2</h4>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_이메일_v2_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v2/login HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 56
+Host: localhost:8080
+
+{"email":"invalidEmail@email.com","password":"password"}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_이메일_v2_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_이메일_v2_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 97
+
+{"errorMessage":"존재하지 않는 회원이거나 비밀번호가 일치하지 않습니다."}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_이메일_v2_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>errorMessage</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">로그인 실패 사유</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="sect3">
+          <h4 id="_실패_유효하지_않은_비밀번호_v2">실패 - 유효하지 않은 비밀번호 - v2</h4>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_비밀번호_v2_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v2/login HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 56
+Host: localhost:8080
+
+{"email":"email@email.com","password":"invalidPassword"}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_비밀번호_v2_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_비밀번호_v2_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 97
+
+{"errorMessage":"존재하지 않는 회원이거나 비밀번호가 일치하지 않습니다."}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_유효하지_않은_비밀번호_v2_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>errorMessage</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">로그인 실패 사유</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="sect2">
+        <h3 id="_로그아웃">로그아웃</h3>
+        <div class="sect3">
+          <h4 id="_성공_v1_2">성공 - v1</h4>
+          <div class="sect4">
+            <h5 id="_성공_v1_2_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/logout HTTP/1.1
 Host: localhost:8080</code></pre>
               </div>
             </div>
           </div>
           <div class="sect4">
-            <h5 id="_로그아웃_http_response">HTTP response</h5>
+            <h5 id="_성공_v1_2_http_response">HTTP response</h5>
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: memberId=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT</code></pre>
+Set-Cookie: memberId=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT</code></pre>
               </div>
             </div>
+          </div>
+        </div>
+        <div class="sect3">
+          <h4 id="_성공_v2_2">성공 - v2</h4>
+          <div class="sect4">
+            <h5 id="_성공_v2_2_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v2/logout HTTP/1.1
+Host: localhost:8080</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_2_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+                <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK</code></pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="sect1">
+    <h2 id="_회원">회원</h2>
+    <div class="sectionbody">
+      <div class="sect2">
+        <h3 id="_회원_생성">회원 생성</h3>
+        <div class="sect3">
+          <h4 id="_성공_v1_3">성공 - v1</h4>
+          <div class="sect4">
+            <h5 id="_성공_v1_3_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/members HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 87
+Host: localhost:8080
+
+{"email":"example@gmail.com","password":"0000","name":"member","age":null,"hobby":null}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v1_3_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>age</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">나이</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>hobby</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">취미</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v1_3_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+                <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created</code></pre>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="sect3">
+          <h4 id="_성공_v2_3">성공 - v2</h4>
+          <div class="sect4">
+            <h5 id="_성공_v2_3_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v2/members HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 87
+Host: localhost:8080
+
+{"email":"email@email.com","password":"password","name":"name","age":null,"hobby":null}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_3_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>age</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">나이</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>hobby</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">취미</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_3_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+                <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created</code></pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="sect2">
+        <h3 id="_회원_마이페이지">회원 마이페이지</h3>
+        <div class="sect3">
+          <h4 id="_실패_v1">실패 - v1</h4>
+          <div class="sect4">
+            <h5 id="_실패_v1_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/members/my-page HTTP/1.1
+Host: localhost:8080</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v1_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+Content-Length: 60
+
+{"errorMessage":"No login info exists. Please login first."}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v1_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>errorMessage</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">회원 정보 조회 불가 사유</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="sect3">
+          <h4 id="_실패_v2">실패 - v2</h4>
+          <div class="sect4">
+            <h5 id="_실패_v2_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v2/members/my-page HTTP/1.1
+Host: localhost:8080</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v2_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+Content-Length: 60
+
+{"errorMessage":"No login info exists. Please login first."}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v2_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>errorMessage</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">회원 정보 조회 불가 사유</p></td>
+              </tr>
+              </tbody>
+            </table>
           </div>
         </div>
       </div>
@@ -2396,73 +2739,211 @@ Set-Cookie: memberId=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT</code></
       <div class="sect2">
         <h3 id="_게시글_생성">게시글 생성</h3>
         <div class="sect3">
-          <h4 id="_게시글_생성_http_request">HTTP request</h4>
-          <div class="listingblock">
-            <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /posts HTTP/1.1
+          <h4 id="_성공_v1_4">성공 - v1</h4>
+          <div class="sect4">
+            <h5 id="_성공_v1_4_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/posts HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 50
+Content-Length: 47
 Host: localhost:8080
+Cookie: memberId=6
 
-{"memberId":6,"title":"title","content":"content"}</code></pre>
+{"title":"post-title","content":"post-content"}</code></pre>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="sect3">
-          <h4 id="_게시글_생성_http_response">HTTP response</h4>
-          <div class="listingblock">
-            <div class="content">
+          <div class="sect4">
+            <h5 id="_성공_v1_4_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
 Content-Type: application/json
 Content-Length: 16
 
 {"identifier":3}</code></pre>
+              </div>
             </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v1_4_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>identifier</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
+              </tr>
+              </tbody>
+            </table>
           </div>
         </div>
         <div class="sect3">
-          <h4 id="_게시글_생성_response_fields">Response fields</h4>
-          <table class="tableblock frame-all grid-all stretch">
-            <colgroup>
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3334%;">
-            </colgroup>
-            <thead>
-            <tr>
-              <th class="tableblock halign-left valign-top">Path</th>
-              <th class="tableblock halign-left valign-top">Type</th>
-              <th class="tableblock halign-left valign-top">Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>identifier</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
-            </tr>
-            </tbody>
-          </table>
+          <h4 id="_성공_v2_4">성공 - v2</h4>
+          <div class="sect4">
+            <h5 id="_성공_v2_4_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/posts HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 47
+Host: localhost:8080
+Cookie: memberId=6
+
+{"title":"post-title","content":"post-content"}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_4_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json
+Content-Length: 16
+
+{"identifier":3}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_v2_4_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>identifier</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="sect3">
+          <h4 id="_실패_v2_2">실패 - v2</h4>
+          <div class="sect4">
+            <h5 id="_실패_v2_2_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v2/posts HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 47
+Host: localhost:8080
+
+{"title":"post-title","content":"post-content"}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v2_2_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 내용</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v2_2_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+Content-Length: 60
+
+{"errorMessage":"No login info exists. Please login first."}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_v2_2_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>errorMessage</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 생성 불가 사유</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
       <div class="sect2">
         <h3 id="_게시글_조회">게시글 조회</h3>
         <div class="sect3">
-          <h4 id="_단건_조회_2">단건 조회</h4>
+          <h4 id="_단건_조회">단건 조회</h4>
           <div class="sect4">
-            <h5 id="_단건_조회_2_http_request">HTTP request</h5>
+            <h5 id="_단건_조회_http_request">HTTP request</h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /posts/2 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/posts/2 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Host: localhost:8080</code></pre>
               </div>
             </div>
           </div>
           <div class="sect4">
-            <h5 id="_단건_조회_2_path_parameters">Path parameters</h5>
+            <h5 id="_단건_조회_path_parameters">Path parameters</h5>
             <table class="tableblock frame-all grid-all stretch">
-              <caption class="title">Table 1. /posts/{postId}</caption>
+              <caption class="title">Table 1. /api/v1/posts/{postId}</caption>
               <colgroup>
                 <col style="width: 50%;">
                 <col style="width: 50%;">
@@ -2482,19 +2963,19 @@ Host: localhost:8080</code></pre>
             </table>
           </div>
           <div class="sect4">
-            <h5 id="_단건_조회_2_http_response">HTTP response</h5>
+            <h5 id="_단건_조회_http_response">HTTP response</h5>
             <div class="listingblock">
               <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
 Content-Length: 120
 
-{"postId":2,"title":"post-title","content":"post-content","createdAt":"2023-01-03T17:35:24.932315","createdBy":"member"}</code></pre>
+{"postId":2,"title":"post-title","content":"post-content","createdAt":"2023-01-05T01:26:40.841429","createdBy":"member"}</code></pre>
               </div>
             </div>
           </div>
           <div class="sect4">
-            <h5 id="_단건_조회_2_response_fields">Response fields</h5>
+            <h5 id="_단건_조회_response_fields">Response fields</h5>
             <table class="tableblock frame-all grid-all stretch">
               <colgroup>
                 <col style="width: 33.3333%;">
@@ -2544,7 +3025,7 @@ Content-Length: 120
             <h5 id="_페이징_조회_http_request">HTTP request</h5>
             <div class="listingblock">
               <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /posts?page=0&amp;size=10 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/posts?page=0&amp;size=10 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Host: localhost:8080</code></pre>
               </div>
@@ -2629,125 +3110,232 @@ Content-Length: 59
       <div class="sect2">
         <h3 id="_게시글_수정">게시글 수정</h3>
         <div class="sect3">
-          <h4 id="_게시글_수정_http_request">HTTP request</h4>
-          <div class="listingblock">
-            <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /posts/4 HTTP/1.1
+          <h4 id="_성공">성공</h4>
+          <div class="sect4">
+            <h5 id="_성공_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/posts/4 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 45
 Host: localhost:8080
 Cookie: memberId=7
 
 {"title":"new-title","content":"new-content"}</code></pre>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="sect3">
-          <h4 id="_게시글_수정_request_fields">Request fields</h4>
-          <table class="tableblock frame-all grid-all stretch">
-            <colgroup>
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3334%;">
-            </colgroup>
-            <thead>
-            <tr>
-              <th class="tableblock halign-left valign-top">Path</th>
-              <th class="tableblock halign-left valign-top">Type</th>
-              <th class="tableblock halign-left valign-top">Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 내용</p></td>
-            </tr>
-            </tbody>
-          </table>
-        </div>
-        <div class="sect3">
-          <h4 id="_게시글_수정_path_parameters">Path parameters</h4>
-          <table class="tableblock frame-all grid-all stretch">
-            <caption class="title">Table 1. /posts/{postId}</caption>
-            <colgroup>
-              <col style="width: 50%;">
-              <col style="width: 50%;">
-            </colgroup>
-            <thead>
-            <tr>
-              <th class="tableblock halign-left valign-top">Parameter</th>
-              <th class="tableblock halign-left valign-top">Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
-            </tr>
-            </tbody>
-          </table>
-        </div>
-        <div class="sect3">
-          <h4 id="_게시글_수정_http_response">HTTP response</h4>
-          <div class="listingblock">
-            <div class="content">
+          <div class="sect4">
+            <h5 id="_성공_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 내용</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_path_parameters">Path parameters</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <caption class="title">Table 1. /api/v1/posts/{postId}</caption>
+              <colgroup>
+                <col style="width: 50%;">
+                <col style="width: 50%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Parameter</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
 Content-Length: 118
 
-{"postId":4,"title":"new-title","content":"new-content","createdAt":"2023-01-03T17:35:25.011568","createdBy":"member"}</code></pre>
+{"postId":4,"title":"new-title","content":"new-content","createdAt":"2023-01-05T01:26:40.910983","createdBy":"member"}</code></pre>
+              </div>
             </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_성공_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 내용</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdAt</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 아이디</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdBy</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 작성자 이름</p></td>
+              </tr>
+              </tbody>
+            </table>
           </div>
         </div>
         <div class="sect3">
-          <h4 id="_게시글_수정_response_fields">Response fields</h4>
-          <table class="tableblock frame-all grid-all stretch">
-            <colgroup>
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3333%;">
-              <col style="width: 33.3334%;">
-            </colgroup>
-            <thead>
-            <tr>
-              <th class="tableblock halign-left valign-top">Path</th>
-              <th class="tableblock halign-left valign-top">Type</th>
-              <th class="tableblock halign-left valign-top">Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 내용</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdAt</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 아이디</p></td>
-            </tr>
-            <tr>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdBy</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-              <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 작성자 이름</p></td>
-            </tr>
-            </tbody>
-          </table>
+          <h4 id="_실패">실패</h4>
+          <div class="sect4">
+            <h5 id="_실패_http_request">HTTP request</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v2/posts/5 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 45
+Host: localhost:8080
+Cookie: sessionId=aaed7515-f4a4-4551-8fe9-bcf8bb357a65
+
+{"title":"new-title","content":"new-content"}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_request_fields">Request fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
+              </tr>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 내용</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_path_parameters">Path parameters</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <caption class="title">Table 1. /api/v2/posts/{postId}</caption>
+              <colgroup>
+                <col style="width: 50%;">
+                <col style="width: 50%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Parameter</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_http_response">HTTP response</h5>
+            <div class="listingblock">
+              <div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 403 Forbidden
+Content-Type: application/json
+Content-Length: 60
+
+{"errorMessage":"No login info exists. Please login first."}</code></pre>
+              </div>
+            </div>
+          </div>
+          <div class="sect4">
+            <h5 id="_실패_response_fields">Response fields</h5>
+            <table class="tableblock frame-all grid-all stretch">
+              <colgroup>
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3333%;">
+                <col style="width: 33.3334%;">
+              </colgroup>
+              <thead>
+              <tr>
+                <th class="tableblock halign-left valign-top">Path</th>
+                <th class="tableblock halign-left valign-top">Type</th>
+                <th class="tableblock halign-left valign-top">Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>errorMessage</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+                <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 생성 불가 사유</p></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     </div>
@@ -2756,7 +3344,7 @@ Content-Length: 118
 <div id="footer">
   <div id="footer-text">
     Version 0.0.1-SNAPSHOT<br>
-    Last updated 2023-01-03 17:34:55 +0900
+    Last updated 2023-01-05 01:25:00 +0900
   </div>
 </div>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css" rel="stylesheet">

--- a/src/test/java/devcourse/board/domain/post/PostServiceTest.java
+++ b/src/test/java/devcourse/board/domain/post/PostServiceTest.java
@@ -36,17 +36,17 @@ class PostServiceTest {
     }
 
     @Test
-    @DisplayName("게시글 생성")
+    @DisplayName("게시글을 작성할 수 있다.")
     void createPost() {
         // given
         Member member = this.dummyMember;
         memberRepository.save(member);
 
         PostCreationRequest creationRequest =
-                new PostCreationRequest(member.getId(), "post-title", "post-content");
+                new PostCreationRequest("post-title", "post-content");
 
         // when
-        Long createdPostId = postService.createPost(creationRequest);
+        Long createdPostId = postService.createPost(member.getId(), creationRequest);
 
         // then
         Post findPost = postRepository.findById(createdPostId).get();

--- a/src/test/java/devcourse/board/domain/post/PostServiceTest.java
+++ b/src/test/java/devcourse/board/domain/post/PostServiceTest.java
@@ -5,6 +5,7 @@ import devcourse.board.domain.member.model.Member;
 import devcourse.board.domain.post.model.Post;
 import devcourse.board.domain.post.model.PostCreationRequest;
 import devcourse.board.domain.post.model.PostUpdateRequest;
+import devcourse.board.global.errors.exception.ForbiddenException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -69,7 +70,7 @@ class PostServiceTest {
         PostUpdateRequest updateRequest = new PostUpdateRequest("new-title", "new-content");
 
         // when & then
-        assertThrows(IllegalStateException.class, () -> {
+        assertThrows(ForbiddenException.class, () -> {
             postService.updatePost(unAuthorizedMemberId, post.getId(), updateRequest);
         });
     }

--- a/src/test/java/devcourse/board/web/api/v1/MemberApiV1Test.java
+++ b/src/test/java/devcourse/board/web/api/v1/MemberApiV1Test.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import devcourse.board.domain.member.MemberRepository;
 import devcourse.board.domain.member.model.Member;
 import devcourse.board.domain.member.model.MemberJoinRequest;
-import devcourse.board.web.authentication.AuthenticationUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,8 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
-
-import javax.servlet.http.Cookie;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
@@ -65,25 +62,19 @@ class MemberApiV1Test {
     }
 
     @Test
-    @DisplayName("회원 단건 조회")
-    void getMember() throws Exception {
+    @DisplayName("로그인 하지 않은 사용자는 자신의 정보를 조회할 수 없다.")
+    void should_return_unauthorized_when_non_login_member_access_own_info() throws Exception {
         // given
-        Member member = Member.create("example@email.com", "0000", "member");
+        Member member = Member.create("email@email.com", "password", "name");
         memberRepository.save(member);
 
-        Cookie idCookie = new Cookie(AuthenticationUtil.COOKIE_NAME, String.valueOf(member.getId()));
-
         // when & then
-        mockMvc.perform(get("/api/v1/members/{memberId}", member.getId())
-                        .cookie(idCookie))
-                .andExpect(status().isOk())
+        mockMvc.perform(get("/api/v1/members/my-page", member.getId()))
+                .andExpect(status().isUnauthorized())
                 .andDo(print())
-                .andDo(document("member-get-one-v1",
+                .andDo(document("member-my-page-v1",
                         responseFields(
-                                fieldWithPath("email").type(STRING).description("이메일"),
-                                fieldWithPath("name").type(STRING).description("이름"),
-                                fieldWithPath("age").type(NUMBER).description("나이").optional(),
-                                fieldWithPath("hobby").type(STRING).description("취미").optional()
+                                fieldWithPath("errorMessage").type(STRING).description("회원 정보 조회 불가 사유")
                         )
                 ));
     }

--- a/src/test/java/devcourse/board/web/api/v1/PostApiV1Test.java
+++ b/src/test/java/devcourse/board/web/api/v1/PostApiV1Test.java
@@ -61,17 +61,19 @@ class PostApiV1Test {
         memberRepository.save(member);
 
         PostCreationRequest creationRequest =
-                new PostCreationRequest(member.getId(), "title", "content");
+                new PostCreationRequest("post-title", "post-content");
+
+        Cookie memberIdCookie = new Cookie(AuthenticationUtil.COOKIE_NAME, String.valueOf(member.getId()));
 
         // when & then
         mockMvc.perform(post("/api/v1/posts")
+                        .cookie(memberIdCookie)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(creationRequest)))
                 .andExpect(status().isCreated())
                 .andDo(print())
                 .andDo(document("post-create-v1",
                         requestFields(
-                                fieldWithPath("memberId").description("회원 식별자"),
                                 fieldWithPath("title").description("게시글 제목"),
                                 fieldWithPath("content").description("게시글 내용")
                         ),

--- a/src/test/java/devcourse/board/web/api/v2/LoginApiV2Test.java
+++ b/src/test/java/devcourse/board/web/api/v2/LoginApiV2Test.java
@@ -1,0 +1,130 @@
+package devcourse.board.web.api.v2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import devcourse.board.domain.login.model.LoginRequest;
+import devcourse.board.domain.member.MemberRepository;
+import devcourse.board.domain.member.model.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional
+class LoginApiV2Test {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("로그인 성공")
+    void login() throws Exception {
+        // given
+        String email = "email@email.com";
+        String password = "password";
+        Member member = Member.create(email, password, "name");
+        memberRepository.save(member);
+
+        LoginRequest loginRequest = new LoginRequest(email, password);
+
+        // when & then
+        mockMvc.perform(post("/api/v2/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("member-login-v2",
+                        requestFields(
+                                fieldWithPath("email").type(STRING).description("이메일"),
+                                fieldWithPath("password").type(STRING).description("비밀번호")
+                        )));
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 유효하지 않은 이메일을 입력시 400을 리턴한다.")
+    void should_return_400_for_invalid_email_when_login() throws Exception {
+        // given
+        String email = "email@email.com";
+        String password = "password";
+
+        Member member = Member.create(email, password, "name");
+        memberRepository.save(member);
+
+        String invalidEmail = "invalidEmail@email.com";
+        LoginRequest loginRequest = new LoginRequest(invalidEmail, password);
+
+        // when & then
+        mockMvc.perform(post("/api/v2/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isBadRequest())
+                .andDo(print())
+                .andDo(document("member-login-fail-invalid-email-v2",
+                        requestFields(
+                                fieldWithPath("email").type(STRING).description("이메일"),
+                                fieldWithPath("password").type(STRING).description("비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("errorMessage").type(STRING).description("로그인 실패 사유")
+                        )));
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 유효하지 않은 비밀번호를 입력시 400을 리턴한다.")
+    void should_return_400_for_invalid_password_when_login() throws Exception {
+        // given
+        String email = "email@email.com";
+        String password = "password";
+
+        Member member = Member.create(email, password, "name");
+        memberRepository.save(member);
+
+        String invalidPassword = "invalidPassword";
+        LoginRequest loginRequest = new LoginRequest(email, invalidPassword);
+
+        // when & then
+        mockMvc.perform(post("/api/v2/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isBadRequest())
+                .andDo(print())
+                .andDo(document("member-login-fail-invalid-password-v2",
+                        requestFields(
+                                fieldWithPath("email").type(STRING).description("이메일"),
+                                fieldWithPath("password").type(STRING).description("비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("errorMessage").type(STRING).description("로그인 실패 사유")
+                        )));
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공")
+    void logout_success() throws Exception {
+        // when & then
+        mockMvc.perform(post("/api/v2/logout"))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("member-logout-v2"));
+    }
+}

--- a/src/test/java/devcourse/board/web/api/v2/MemberApiV2Test.java
+++ b/src/test/java/devcourse/board/web/api/v2/MemberApiV2Test.java
@@ -1,0 +1,82 @@
+package devcourse.board.web.api.v2;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import devcourse.board.domain.member.MemberRepository;
+import devcourse.board.domain.member.model.Member;
+import devcourse.board.domain.member.model.MemberJoinRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional
+class MemberApiV2Test {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("회원 가입 성공")
+    void join() throws Exception {
+        // given
+        MemberJoinRequest joinRequest =
+                new MemberJoinRequest("email@email.com", "password", "name");
+
+        // when & then
+        mockMvc.perform(post("/api/v2/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andExpect(status().isCreated())
+                .andDo(print())
+                .andDo(document("member-join-v2",
+                        requestFields(
+                                fieldWithPath("email").type(STRING).description("이메일"),
+                                fieldWithPath("password").type(STRING).description("비밀번호"),
+                                fieldWithPath("name").type(STRING).description("이름"),
+                                fieldWithPath("age").type(NUMBER).description("나이").optional(),
+                                fieldWithPath("hobby").type(STRING).description("취미").optional()
+                        )));
+    }
+
+    @Test
+    @DisplayName("로그인 하지 않은 사용자는 자신의 정보를 조회할 수 없다.")
+    void should_return_unauthorized_when_non_login_member_access_own_info() throws Exception {
+        // given
+        Member member = Member.create("email@email.com", "password", "name");
+        memberRepository.save(member);
+
+        // when & then
+        mockMvc.perform(get("/api/v2/members/my-page", member.getId()))
+                .andExpect(status().isUnauthorized())
+                .andDo(print())
+                .andDo(document("member-my-page-v2",
+                        responseFields(
+                                fieldWithPath("errorMessage").type(STRING).description("회원 정보 조회 불가 사유")
+                        )
+                ));
+    }
+}

--- a/src/test/java/devcourse/board/web/api/v2/PostApiV2Test.java
+++ b/src/test/java/devcourse/board/web/api/v2/PostApiV2Test.java
@@ -1,0 +1,152 @@
+package devcourse.board.web.api.v2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import devcourse.board.domain.member.MemberRepository;
+import devcourse.board.domain.member.model.Member;
+import devcourse.board.domain.post.PostRepository;
+import devcourse.board.domain.post.model.Post;
+import devcourse.board.domain.post.model.PostCreationRequest;
+import devcourse.board.domain.post.model.PostUpdateRequest;
+import devcourse.board.web.authentication.SessionManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional
+class PostApiV2Test {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private SessionManager sessionManager;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    private Member dummyMember;
+
+    @BeforeEach
+    void setUp() {
+        this.dummyMember = Member.create("example@email.com", "0000", "member");
+    }
+
+    @Test
+    @DisplayName("게시글 생성 성공 - 로그인한 회원만 게시글을 작성할 수 있다.")
+    void createPost() throws Exception {
+        // given
+        Member member = this.dummyMember;
+        memberRepository.save(member);
+
+        PostCreationRequest creationRequest =
+                new PostCreationRequest("post-title", "post-content");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        sessionManager.registerNewSession(response, member.getId());
+
+        // when & then
+        mockMvc.perform(post("/api/v2/posts")
+                        .cookie(response.getCookies())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(creationRequest)))
+                .andExpect(status().isCreated())
+                .andDo(print())
+                .andDo(document("post-create-v2",
+                        requestFields(
+                                fieldWithPath("title").description("게시글 제목"),
+                                fieldWithPath("content").description("게시글 내용")
+                        ),
+                        responseFields(
+                                fieldWithPath("identifier").description("게시글 식별자")
+                        )));
+    }
+
+    @Test
+    @DisplayName("게시글 생성 실패 - 로그인하지 않은 회원은 게시글을 작성할 수 없다.")
+    void should_return_unAuthorized_when_non_login_member_attempt_to_update_post() throws Exception {
+        // given
+        Member member = this.dummyMember;
+        memberRepository.save(member);
+
+        PostCreationRequest creationRequest =
+                new PostCreationRequest("post-title", "post-content");
+
+        // when & then
+        mockMvc.perform(post("/api/v2/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(creationRequest)))
+                .andExpect(status().isUnauthorized())
+                .andDo(print())
+                .andDo(document("post-create-fail-v2",
+                        requestFields(
+                                fieldWithPath("title").description("게시글 제목"),
+                                fieldWithPath("content").description("게시글 내용")
+                        ),
+                        responseFields(
+                                fieldWithPath("errorMessage").description("게시글 생성 불가 사유")
+                        )));
+    }
+
+    @Test
+    @DisplayName("게시글 수정 실패 - 작성자 외의 회원이 게시글을 수정 시 403을 리턴한다.")
+    void should_return_forbidden_for_non_login_member() throws Exception {
+        // given
+        Member postAuthor = this.dummyMember;
+        Member otherMember = Member.create("otherMember@email.com", "password", "name");
+        memberRepository.save(postAuthor);
+        memberRepository.save(otherMember);
+
+        Post post = Post.create(postAuthor, "old-title", "old-content");
+        postRepository.save(post);
+
+        PostUpdateRequest updateRequest = new PostUpdateRequest("new-title", "new-content");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        sessionManager.registerNewSession(response, otherMember.getId());
+
+        // when & then
+        mockMvc.perform(patch("/api/v2/posts/{postId}", post.getId())
+                        .cookie(response.getCookies())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isForbidden())
+                .andDo(print())
+                .andDo(document("post-update-fail-v2",
+                        pathParameters(
+                                parameterWithName("postId").description("게시글 식별자")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").description("게시글 제목"),
+                                fieldWithPath("content").description("게시글 내용")
+                        ),
+                        responseFields(
+                                fieldWithPath("errorMessage").description("게시글 생성 불가 사유")
+                        )));
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -3,11 +3,13 @@ spring:
     properties:
       hibernate:
         format_sql: true
-
   output:
     ansi:
       enabled: always
-#
+
+cookie:
+  max-age: 600
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

안녕하세요 앨런님 승훈님 환님!
팀 2차 미션 (세션을 이용한 인증/인가) 을 구현했습니다.
리뷰 잘부탁드리겠습니다~!


## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

- 세션을 직접 구현합니다.
- 구현한 세션을 바탕으로 인증/인가를 진행합니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- 로그인 v2
- 내 정보 조회기능 v2
- 게시글에 사용자 정보를 저장한다.
- 로그인된 사용자만 게시글을 만들 수 있다.
  - `401`을 내려주도록 구현
- 본인의 게시글만 수정/삭제할 수 있다.
  - `403`을 내려주도록 구현 
  

기타

![image](https://user-images.githubusercontent.com/65555299/210610879-95049b3c-a299-45de-97b7-559afcf9bf5c.png)

- 도메인이 웹을 의존하지 않도록 구성하는 것의 필요성을 느껴, 
기존의 API-Domain 구조로 되어있던 패키지를 WEB-Domain 구조로 변경하였습니다. 
- 다만 해당 구조에서 `웹이 도메인을 너무 강하게 의존하지는 않는건가?` 라는 생각이 들었고, 
향후 최대한 덜 의존적이도록 코드를 고쳐나가보겠습니다. (예: Web 전용 DTO를 사용)

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

- 코멘트로 남기겠습니다!

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

- API 호출 실패 테스트 케이스를 작성하였습니다.
- 기타 궁금한 사항은 코멘트로 남기겠습니다!
